### PR TITLE
Style: SignUP 컴포넌트 및 회원가입 축하 Modal 컴포넌트 뷰 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "concurrently": "^8.2.2",
         "dotenv": "^16.4.5",
+        "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router": "^6.26.0",
@@ -4857,7 +4858,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5399,8 +5399,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -5497,7 +5495,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "concurrently": "^8.2.2",
     "dotenv": "^16.4.5",
+    "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router": "^6.26.0",

--- a/src/Components/Modal/index.jsx
+++ b/src/Components/Modal/index.jsx
@@ -1,0 +1,20 @@
+import PropTypes from "prop-types";
+
+function Modal({ isOpen, children }) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="flex items-center justify-center bg-white p-6 rounded-lg shadow-lg relative min-w-[300px]">
+        <div className="flex-col items-center justify-center">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+Modal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  children: PropTypes.node,
+};
+
+export default Modal;

--- a/src/Components/SignUp/index.jsx
+++ b/src/Components/SignUp/index.jsx
@@ -1,0 +1,117 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import Modal from "../Modal";
+
+function SignUp() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const navigate = useNavigate();
+
+  const openModal = () => setIsModalOpen(true);
+  const navigateToMainPage = () => {
+    setIsModalOpen(false);
+    navigate("/");
+  };
+
+  return (
+    <div className="flex-grow flex items-center justify-center p-4">
+      <form className="bg-white shadow-md rounded border-gray-600 p-6 m-4 w-[400px]">
+        <div className="mb-4">
+          <label
+            className="block text-gray-700 text-sm font-bold mb-2"
+            htmlFor="user-mail"
+          >
+            이메일
+          </label>
+          <input
+            className="w-8/12 h-12 shadow border rounded-l p-3 text-gray-700 leading-tight focus:border-gray-700"
+            id="user-mail"
+            name="user-mail"
+            type="email"
+          />
+          <button
+            className="w-4/12 h-12 bg-blue-400 hover:bg-blue-500 text-white font-bold py-2 px-4 rounded-r focus:shadow-outline"
+            type="button"
+          //TODO: 추후 데이터베이스 연결 및 아이디 중복 확인 로직 구현
+          >
+            중복확인
+          </button>
+        </div>
+        <div className="mb-4">
+          <label
+            className="block text-gray-700 text-sm font-bold mb-2"
+            htmlFor="nickname"
+          >
+            닉네임
+          </label>
+          <input
+            className="w-full h-12 shadow border rounded p-3 text-gray-700 leading-tight focus:border-gray-700"
+            id="nickname"
+            name="nickname"
+            type="text"
+          />
+        </div>
+        <div className="mb-6">
+          <label
+            className="block text-gray-700 text-sm font-bold mb-2"
+            htmlFor="password"
+          >
+            비밀번호
+          </label>
+          <input
+            className="w-full h-12 shadow border rounded p-3 text-gray-700 leading-tight focus:border-gray-700"
+            id="password"
+            name="password"
+            type="password"
+          />
+        </div>
+        <div className="mb-6">
+          <label
+            className="block text-gray-700 text-sm font-bold mb-2"
+            htmlFor="password check"
+          >
+            비밀번호 확인
+          </label>
+          <input
+            className="w-full h-12 shadow border rounded p-3 text-gray-700 leading-tight focus:border-gray-700"
+            id="password-check"
+            name="password-check"
+            type="password-check"
+          />
+        </div>
+        <a
+          className="inline-block m-2 font-bold text-sm text-blue-500 hover:underline"
+          href="#"
+        >
+          개인정보 약관 보기
+        </a>
+        <label className="mb-3 block text-gray-500 font-bold">
+          <input className="m-2 mb-6 leading-tight" name="checkbox" type="checkbox" />
+          <span className="text-sm">개인정보약관에 동의합니다.</span>
+        </label>
+        <div className="flex items-center justify-center mb-2">
+          <button
+            className="w-full bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 mb-4 rounded-md focus:shadow-outline"
+            type="button"
+            //TODO: 현재 단순히 모달창을 여는 로직이며, 추후 서버와 연결하여 실제 가입 로직 구현
+            onClick={openModal}
+          >
+            가입하기
+          </button>
+        </div>
+      </form>
+      <Modal isOpen={isModalOpen} onClose={navigateToMainPage}>
+        <h2 className="text-xl font-semibold mb-4">DELIORDER</h2>
+        <p>신규회원가입을 축하합니다!</p>
+        <button
+          className="mt-4 px-4 py-2 bg-blue-400 hover:bg-blue-500 text-white font-bold rounded-md focus:shadow-outline text-center"
+          onClick={navigateToMainPage}
+        >
+          메인페이지로 이동하기
+        </button>
+      </Modal>
+    </div>
+  );
+}
+
+export default SignUp;


### PR DESCRIPTION
# 칸반 명
[[APP] 가입하기 화면 만들기](https://www.notion.so/startled-hamster/APP-a8f14865e75f4239bb88cec476b2f928)

# Mock up
![image](https://github.com/user-attachments/assets/2015aa4a-4633-4a3a-bce5-837e8c5c555b)
![image](https://github.com/user-attachments/assets/29e2f177-c341-4978-b147-3bda5435c697)

# 구현화면
![image](https://github.com/user-attachments/assets/cb5460b9-9210-42ab-bef3-5e253838ac30)
![image](https://github.com/user-attachments/assets/b86a2419-72b3-43a8-b8ea-1506bf4a9b89)


# 해당 업무 리스트
- [x]  닉네임을 입력할 수 있는 칸이 있어야 합니다.
- [x]  아이디를 입력할 수 있는 칸이 있어야 합니다.
- [x]  비밀번호을 입력할 수 있는 칸이 있어야 합니다.
- [x]  개인정보 관련 약관을 확인한 뒤 동의했음을 체크할 수 있는 버튼이 있어야합니다.
- [x]  제출할 수 있는 버튼이 있어야 합니다.

- [x]  회원가입 완료 안내창이 있어야합니다.
    - [x]  가입을 축하하는 안내 문구가 있어야 합니다.
    - [x]  홈으로 이동하기 버튼이 있어야 합니다.

# 상세 기술

- 로그인 화면에서 가입하기 버튼을 누르면 보이는 로컬 가입화면 창입니다.
- 회원가입 완료 및 축하문구 출력 안내창 관련하여 모달창 컴포넌트를 생성하였습니다.

# 참고사항

- 재사용이 가능한 모달컴포넌트`<Modal />`를 만들었으니 참고해주시기 바랍니다. 
- 리액트 관련 `prop-types` 패키지를 설치하여 package.json에 변동사항이 있습니다. 
아래를 실행해주세요.
```
npm install
```

# PR 체크 사항

## 주의 사항

- [x]  PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x]  conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x]  가장 최신 브랜치를 pull 하였습니다.
- [x]  base 브랜치명을 확인하였습니다.
- [x]  코드 컨벤션을 모두 확인하였습니다.
- [x]  브랜치명을 확인하였습니다.
- [x]  작업 중 dependency 변경사항이 있는 경우 안내해주세요!