### PR TITLE
Feat: 로그인 한 송신자 - 보냈던 행동소포들 정보를 다시 볼 수 있는 페이지 구현

### DIFF
--- a/src/renderer/Components/App.jsx
+++ b/src/renderer/Components/App.jsx
@@ -6,6 +6,7 @@ import Login from "./Login";
 import SignUp from "./SignUp";
 import ReceivingPackage from "./RecevingPackage";
 import CreatingPackage from "./CreatingPackage";
+import MyPackages from "./MyPackages";
 import { useState } from "react";
 
 function App() {
@@ -21,6 +22,7 @@ function App() {
           <Route path="/signUp" element={<SignUp />} />
           <Route path="/package/new" element={<CreatingPackage />} />
           <Route path="/package/receiving" element={<ReceivingPackage />} />
+          <Route path="/myPackages" element={<MyPackages />} />
         </Routes>
       </div>
     </div>

--- a/src/renderer/Components/MyPackages/index.jsx
+++ b/src/renderer/Components/MyPackages/index.jsx
@@ -1,0 +1,54 @@
+import mockData from "./mockData.json";
+
+function MyPackages() {
+  // TODO: userDBAllData는 목데이터로 front 로직 구현시 데이터베이스에서 실제정보를 불러와주는 로직 필요
+  const userDBAllData = mockData;
+  const latestOrderUserHistory = userDBAllData.history.slice().reverse();
+  return (
+    <div className="flex min-h-screen items-start justify-center bg-gray-50 p-8">
+      <div className="mt-6 w-full max-w-3xl space-y-6">
+        {/* <div className="text-lg font-bold text-gray-700">▽ 과거행동순</div> */}
+        {latestOrderUserHistory.map((userPackage, index) => (
+          <div
+            key={index}
+            className="rounded-lg border border-gray-300 bg-white p-6 shadow-md transition-shadow duration-300 hover:shadow-lg"
+          >
+            <div className="mb-4 flex items-center justify-between border-b pb-4">
+              <span className="text-lg font-semibold text-blue-600">
+                Package {index + 1}
+              </span>
+              <time className="text-sm text-gray-500">
+                만료일시:{" "}
+                {new Date(userPackage.expireAt.$date).toLocaleDateString()}{" "}
+                {new Date(userPackage.expireAt.$date).toLocaleTimeString()} /{" "}
+                <span
+                  className={`font-bold ${
+                    new Date(userPackage.expireAt.$date) > new Date()
+                      ? "text-green-600"
+                      : "text-red-600"
+                  }`}
+                >
+                  {new Date(userPackage.expireAt.$date) > new Date()
+                    ? "전송가능"
+                    : "만료됨"}
+                </span>
+              </time>
+            </div>
+            <div className="space-y-2">
+              {userPackage.orders.map((order, orderIndex) => (
+                <div key={orderIndex} className="text-gray-700">
+                  {orderIndex + 1}. {order.action}
+                </div>
+              ))}
+            </div>
+            <p className="mt-4 text-right text-sm text-gray-400">
+              일련번호: {userPackage.serialNumber}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default MyPackages;

--- a/src/renderer/Components/MyPackages/index.jsx
+++ b/src/renderer/Components/MyPackages/index.jsx
@@ -10,7 +10,7 @@ function MyPackages() {
         {/* <div className="text-lg font-bold text-gray-700">▽ 과거행동순</div> */}
         {latestOrderUserHistory.map((userPackage, index) => (
           <div
-            key={index}
+            key={userPackage.serialNumber}
             className="rounded-lg border border-gray-300 bg-white p-6 shadow-md transition-shadow duration-300 hover:shadow-lg"
           >
             <div className="mb-4 flex items-center justify-between border-b pb-4">
@@ -36,7 +36,7 @@ function MyPackages() {
             </div>
             <div className="space-y-2">
               {userPackage.orders.map((order, orderIndex) => (
-                <div key={orderIndex} className="text-gray-700">
+                <div key={order.createdAt} className="text-gray-700">
                   {orderIndex + 1}. {order.action}
                 </div>
               ))}

--- a/src/renderer/Components/MyPackages/index.jsx
+++ b/src/renderer/Components/MyPackages/index.jsx
@@ -1,14 +1,43 @@
+import { useState } from "react";
+
 import mockData from "./mockData.json";
+import triangleArrowDown from "@images/triangleArrowDown.svg";
 
 function MyPackages() {
   // TODO: userDBAllData는 목데이터로 front 로직 구현시 데이터베이스에서 실제정보를 불러와주는 로직 필요
   const userDBAllData = mockData;
-  const latestOrderUserHistory = userDBAllData.history.slice().reverse();
+  const [currentSort, setCurrentSort] = useState("sortByNewest");
+  const [userHistorySort, setUserHistorySort] = useState(
+    userDBAllData.history.slice().reverse(),
+  );
+
+  const toggleSort = () => {
+    if (currentSort === "sortByNewest") {
+      setCurrentSort("sortByOldest");
+      setUserHistorySort(userDBAllData.history);
+    } else {
+      setCurrentSort("sortByNewest");
+      setUserHistorySort(userDBAllData.history.slice().reverse());
+    }
+  };
+
   return (
     <div className="flex min-h-screen items-start justify-center bg-gray-50 p-8">
       <div className="mt-6 w-full max-w-3xl space-y-6">
-        {/* <div className="text-lg font-bold text-gray-700">▽ 과거행동순</div> */}
-        {latestOrderUserHistory.map((userPackage, index) => (
+        <div
+          className="flex cursor-pointer flex-row items-center text-lg font-bold text-gray-700"
+          onClick={toggleSort}
+        >
+          <img
+            className="mr-1 h-4 w-4"
+            src={triangleArrowDown}
+            alt="triangleArrowDown"
+          />
+          {currentSort === "sortByNewest"
+            ? "최신패키지 순 정렬"
+            : "과거패키지 순 정렬"}
+        </div>
+        {userHistorySort.map((userPackage, index) => (
           <div
             key={userPackage.serialNumber}
             className="rounded-lg border border-gray-300 bg-white p-6 shadow-md transition-shadow duration-300 hover:shadow-lg"
@@ -36,7 +65,7 @@ function MyPackages() {
             </div>
             <div className="space-y-2">
               {userPackage.orders.map((order, orderIndex) => (
-                <div key={order.createdAt} className="text-gray-700">
+                <div key={order.createdAt.$date} className="text-gray-700">
                   {orderIndex + 1}. {order.action}
                 </div>
               ))}

--- a/src/renderer/Components/MyPackages/index.jsx
+++ b/src/renderer/Components/MyPackages/index.jsx
@@ -47,9 +47,8 @@ function MyPackages() {
                 Package {index + 1}
               </span>
               <time className="text-sm text-gray-500">
-                만료일시:{" "}
-                {new Date(userPackage.expireAt.$date).toLocaleDateString()}{" "}
-                {new Date(userPackage.expireAt.$date).toLocaleTimeString()} /{" "}
+                {"만료일시: "}
+                {new Date(userPackage.expireAt.$date).toLocaleString() + " / "}
                 <span
                   className={`font-bold ${
                     new Date(userPackage.expireAt.$date) > new Date()

--- a/src/renderer/Components/MyPackages/index.jsx
+++ b/src/renderer/Components/MyPackages/index.jsx
@@ -65,6 +65,7 @@ function MyPackages() {
             <div className="space-y-2">
               {userPackage.orders.map((order, orderIndex) => (
                 <div key={order.createdAt.$date} className="text-gray-700">
+                  {/* TODO: 행동의 타입뿐만 아니라 더욱 구체적인 정보를 불러오도록 추가 구현 필요 */}
                   {orderIndex + 1}. {order.action}
                 </div>
               ))}

--- a/src/renderer/Components/MyPackages/mockData.json
+++ b/src/renderer/Components/MyPackages/mockData.json
@@ -1,0 +1,166 @@
+{
+  "_id": {
+    "$oid": "fakeMongooseObjectId"
+  },
+  "nickname": "K",
+  "email": "fakeUserK@gmail.com",
+  "history": [
+    {
+      "_id": {
+        "$oid": "fakeMongooseObjectId"
+      },
+      "serialNumber": 395624,
+      "orders": [
+        {
+          "action": "생성하기",
+          "attachmentName": "dogrun.gif",
+          "attachmentType": "file",
+          "attachmentUrl": "https://fakeAWSUrl",
+          "sourcePath": "",
+          "executionPath": "C:\\Users\\userK\\Downloads",
+          "editingName": "",
+          "_id": {
+            "$oid": "fakeMongooseObjectId"
+          },
+          "createdAt": {
+            "$date": "2024-08-19T12:34:56.789Z"
+          },
+          "updatedAt": {
+            "$date": "2024-08-19T12:34:56.789Z"
+          }
+        }
+      ],
+      "expireAt": {
+        "$date": "2024-08-19T12:44:56.788Z"
+      },
+      "createdAt": {
+        "$date": "2024-08-19T12:34:56.789Z"
+      },
+      "updatedAt": {
+        "$date": "2024-08-19T12:34:56.789Z"
+      },
+      "__v": 0
+    },
+    {
+      "_id": {
+        "$oid": "fakeMongooseObjectId"
+      },
+      "serialNumber": 764320,
+      "orders": [
+        {
+          "action": "이동하기",
+          "attachmentName": "dogwalk.gif",
+          "attachmentType": "file",
+          "attachmentUrl": "",
+          "sourcePath": "C:\\Users\\userK\\Documents",
+          "executionPath": "C:\\Users\\userK\\Pictures",
+          "editingName": "",
+          "_id": {
+            "$oid": "fakeMongooseObjectId"
+          },
+          "createdAt": {
+            "$date": "2024-08-20T14:25:39.900Z"
+          },
+          "updatedAt": {
+            "$date": "2024-08-20T14:25:39.900Z"
+          }
+        },
+        {
+          "action": "삭제하기",
+          "attachmentName": "dogrun.gif",
+          "attachmentType": "file",
+          "attachmentUrl": "",
+          "sourcePath": "C:\\Users\\userK\\Downloads",
+          "executionPath": "",
+          "editingName": "",
+          "_id": {
+            "$oid": "fakeMongooseObjectId"
+          },
+          "createdAt": {
+            "$date": "2024-08-20T14:25:39.901Z"
+          },
+          "updatedAt": {
+            "$date": "2024-08-20T14:25:39.901Z"
+          }
+        }
+      ],
+      "expireAt": {
+        "$date": "2024-08-20T14:35:39.899Z"
+      },
+      "createdAt": {
+        "$date": "2024-08-20T14:25:39.900Z"
+      },
+      "updatedAt": {
+        "$date": "2024-08-20T14:25:39.900Z"
+      },
+      "__v": 0
+    },
+    {
+      "_id": {
+        "$oid": "fakeMongooseObjectId"
+      },
+      "serialNumber": 983724,
+      "orders": [
+        {
+          "action": "생성하기",
+          "attachmentName": "image (2).png",
+          "attachmentType": "file",
+          "attachmentUrl": "https://fakeSAWSUrl2",
+          "sourcePath": "",
+          "executionPath": "C:\\Users\\userK\\Downloads",
+          "editingName": "",
+          "_id": {
+            "$oid": "fakeMongooseObjectId"
+          },
+          "createdAt": {
+            "$date": "2024-08-20T16:38:47.895Z"
+          },
+          "updatedAt": {
+            "$date": "2024-08-20T16:38:47.895Z"
+          }
+        },
+        {
+          "action": "이동하기",
+          "attachmentName": "dogpung.gif",
+          "attachmentType": "file",
+          "attachmentUrl": "",
+          "sourcePath": "C:\\Users\\userK\\Pictures",
+          "executionPath": "C:\\Users\\userK\\Documents",
+          "editingName": "",
+          "_id": {
+            "$oid": "fakeMongooseObjectId"
+          },
+          "createdAt": {
+            "$date": "2024-08-20T16:38:47.896Z"
+          },
+          "updatedAt": {
+            "$date": "2024-08-20T16:38:47.896Z"
+          }
+        }
+      ],
+      "author": {
+        "$oid": "fakeMongooseObjectId"
+      },
+      "expireAt": {
+        "$date": "2024-08-20T16:48:47.894Z"
+      },
+      "createdAt": {
+        "$date": "2024-08-20T16:38:47.897Z"
+      },
+      "updatedAt": {
+        "$date": "2024-08-20T16:38:47.897Z"
+      },
+      "__v": 0
+    }
+  ],
+  "bookmark": [],
+  "loginType": "google",
+  "refreshToken": "fakeToken",
+  "createdAt": {
+    "$date": "2024-08-20T12:28:58.564Z"
+  },
+  "updatedAt": {
+    "$date": "2024-08-20T12:28:58.564Z"
+  },
+  "__v": 0
+}

--- a/src/renderer/Components/Nav/index.jsx
+++ b/src/renderer/Components/Nav/index.jsx
@@ -65,7 +65,7 @@ function Nav({ isLogIn, setIsLogIn }) {
         <div>
           <Link
             //TODO: 추후 내 소포함 페이지 연결 && 백엔드 verify 함수 사용
-            to="#"
+            to="/myPackages"
             className="mr-6 mt-4 inline-block rounded border border-white px-4 py-2 text-sm leading-none text-white hover:border-transparent hover:bg-white hover:text-teal-500 lg:mt-0"
           >
             내 소포함

--- a/src/renderer/assets/images/triangleArrowDown.svg
+++ b/src/renderer/assets/images/triangleArrowDown.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 12.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+]>
+<svg  version="1.1" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="531.74" height="460.5"
+	 viewBox="0 0 531.74 460.5" overflow="visible" enable-background="new 0 0 531.74 460.5" xml:space="preserve">
+<polygon stroke="#000000" points="530.874,0.5 265.87,459.5 0.866,0.5 "/>
+</svg>


### PR DESCRIPTION
# 칸반 명

[[APP]  📤로그인 한 송신자 - 보냈던 행동소포들 정보를 다시 볼 수 있는 페이지 구현](https://www.notion.so/startled-hamster/APP-b1d98bd5bcd2479faad5e1d00a378f8a?pvs=4)

# mock up
![image](https://github.com/user-attachments/assets/e3078e74-32e0-4116-8530-eaae9bdb5bf4)

# 구현화면
![image](https://github.com/user-attachments/assets/2662c628-358c-4a89-80fb-43905d29f053)


# 해당 업무 리스트

- [x]  보낸 행동을 볼 수 있는 버튼이 있어야 합니다.
- [x]  보냈던 행동들 제목, 만료일시, 링크를 다시 볼 수 있어야 합니다.
- [x]  행동이 현재 전송 가능한 상태인지 만료되었는지 상태를 표시해줘야 합니다.

# 상세 기술
- 해당 페이지에서는 사용자가 보낸 행동 리스트를 확인하고, 각 행동의 제목, 만료일시, 링크 등을 다시 확인할 수 있는 기능을 제공합니다. 또한, 각 행동의 현재 상태(전송가능/만료됨)를 표시하여 사용자가 상황을 쉽게 파악할 수 있도록 해줍니다.

# 참고사항

- 뷰 구현 용도로 목데이터를 같은 폴더 내에 `mockData.json`의 형태로 저장해두었습니다. 프론트 로직을 짜실 때에 참고하여 처리해 주시기 바랍니다.

# PR 체크 사항

## 주의 사항

- [x]  PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x]  conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x]  가장 최신 브랜치를 pull 하였습니다.
- [x]  base 브랜치명을 확인하였습니다.
- [x]  코드 컨벤션을 모두 확인하였습니다.
- [x]  브랜치명을 확인하였습니다.
- [x]  작업 중 dependency 변경사항이 있는 경우 안내해주세요!


## 리뷰 반영사항

- 리액트 엘리먼트가 구별되는 고유한 값을 가지도록 처리
- 
