### PR TITLE
Feat: [APP] 📩 수신자 - 매크로 행동 실행 로직 구현 (복제, 실행) 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^1.7.4",
         "concurrently": "^8.2.2",
         "dotenv": "^16.4.5",
+        "mime": "^4.0.4",
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -9949,6 +9950,21 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.4.tgz",
+      "integrity": "sha512-v8yqInVjhXyqP6+Kw4fV3ZzeMRqEW6FotRsKXjRS5VMTNIuXsdRoAvklpoRgSqXm6o9VNH4/C0mgedko9DdLsQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
+      "license": "MIT",
+      "bin": {
+        "mime": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/mime-db": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "axios": "^1.7.4",
     "concurrently": "^8.2.2",
     "dotenv": "^16.4.5",
+    "mime": "^4.0.4",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/main/index.cjs
+++ b/src/main/index.cjs
@@ -3,7 +3,10 @@ require("dotenv").config();
 const { app, BrowserWindow } = require("electron");
 const path = require("path");
 
+require("./ipcMainHandlers/openFolderDialog.cjs");
 require("./ipcMainHandlers/openFileDialog.cjs");
+require("./ipcMainHandlers/replicateFile.cjs");
+require("./ipcMainHandlers/executeFile.cjs");
 require("./ipcMainHandlers/downloadFile.cjs");
 require("./ipcMainHandlers/moveFile.cjs");
 require("./ipcMainHandlers/deleteFile.cjs");

--- a/src/main/ipcMainHandlers/deleteFile.cjs
+++ b/src/main/ipcMainHandlers/deleteFile.cjs
@@ -17,7 +17,7 @@ const deleteFile = () => {
       const trash = (await import("trash")).default;
       await trash(convertedFullPath);
     } catch (error) {
-      console.error("delete-file main handler error:", error);
+      console.error("delete-file main handler 에러:", error);
     }
   });
 };

--- a/src/main/ipcMainHandlers/executeFile.cjs
+++ b/src/main/ipcMainHandlers/executeFile.cjs
@@ -1,0 +1,35 @@
+const { ipcMain } = require("electron");
+const path = require("path");
+const os = require("os");
+const fs = require("fs");
+const { exec } = require("child_process");
+
+const { convertPath } = require("../utils/convertPath.cjs");
+
+const executeFile = () => {
+  ipcMain.handle("execute-file", async (event, order) => {
+    if (order.action !== "실행하기") {
+      console.error(`수신받은 행동이 "실행하기"가 아닙니다.`);
+      return;
+    }
+
+    const platform = os.platform();
+    const folderPath = convertPath(order.executionPath);
+    const filePath = path.join(folderPath, order.attachmentName);
+
+    if (!fs.existsSync(filePath)) {
+      throw new Error("해당 위치에 요청한 파일이 없습니다.");
+    }
+
+    exec(
+      `${platform === "win32" ? "start" : "open"} "${filePath}"`,
+      (error) => {
+        if (error) {
+          console.error("파일 실행하는 중 에러가 발생했습니다.");
+        }
+      },
+    );
+  });
+};
+
+executeFile();

--- a/src/main/ipcMainHandlers/executeFile.cjs
+++ b/src/main/ipcMainHandlers/executeFile.cjs
@@ -2,7 +2,7 @@ const { ipcMain } = require("electron");
 const path = require("path");
 const os = require("os");
 const fs = require("fs");
-const { exec } = require("child_process");
+const { execSync } = require("child_process");
 
 const { convertPath } = require("../utils/convertPath.cjs");
 
@@ -14,21 +14,19 @@ const executeFile = () => {
     }
 
     const platform = os.platform();
-    const folderPath = convertPath(order.executionPath);
-    const filePath = path.join(folderPath, order.attachmentName);
+    const fullPath = path.join(order.executionPath, order.attachmentName);
+    const convertedFullPath = convertPath(fullPath);
 
-    if (!fs.existsSync(filePath)) {
+    if (!fs.existsSync(convertedFullPath)) {
       throw new Error("해당 위치에 요청한 파일이 없습니다.");
     }
-
-    exec(
-      `${platform === "win32" ? "start" : "open"} "${filePath}"`,
-      (error) => {
-        if (error) {
-          console.error("파일 실행하는 중 에러가 발생했습니다.");
-        }
-      },
-    );
+    try {
+      execSync(
+        `${platform === "win32" ? "start" : "open"} "${convertedFullPath}"`,
+      );
+    } catch (error) {
+      console.error("execute-file main handler 에러:", error);
+    }
   });
 };
 

--- a/src/main/ipcMainHandlers/openFileDialog.cjs
+++ b/src/main/ipcMainHandlers/openFileDialog.cjs
@@ -12,9 +12,9 @@ const openFileDialog = () => {
       const selectedFilePath = result.filePaths[0];
       const { base: attachmentName, ext: extension } =
         path.parse(selectedFilePath);
-      const selectFileStat = fs.statSync(selectedFilePath);
+      const selectedFileStat = fs.statSync(selectedFilePath);
 
-      if (selectFileStat.isDirectory()) {
+      if (selectedFileStat.isDirectory()) {
         return { attachmentName, canceled: result.canceled };
       }
 
@@ -32,7 +32,7 @@ const openFileDialog = () => {
         mimeType,
       };
     } catch (error) {
-      console.error("open-file-dialog handler:", error);
+      console.error("open-file-dialog handler 에러:", error);
       return {
         canceled: true,
         filePaths: "",

--- a/src/main/ipcMainHandlers/openFileDialog.cjs
+++ b/src/main/ipcMainHandlers/openFileDialog.cjs
@@ -1,22 +1,35 @@
 const { ipcMain, dialog } = require("electron");
 const path = require("path");
-const os = require("os");
-
-const homeDir = os.homedir();
+const fs = require("fs");
 
 const openFileDialog = () => {
   ipcMain.handle("open-file-dialog", async () => {
     try {
+      const mime = (await import("mime")).default;
       const result = await dialog.showOpenDialog({
-        properties: ["openDirectory"],
+        properties: ["openFile"],
       });
-
       const selectedFilePath = result.filePaths[0];
-      const relativePath = path.relative(homeDir, selectedFilePath);
+      const { base: attachmentName, ext: extension } =
+        path.parse(selectedFilePath);
+      const selectFileStat = fs.statSync(selectedFilePath);
+
+      if (selectFileStat.isDirectory()) {
+        return { attachmentName, canceled: result.canceled };
+      }
+
+      const fileBuffer = fs.readFileSync(selectedFilePath);
+      const baseName = path.basename(selectedFilePath);
+      const fileBase64 = fileBuffer.toString("base64");
+      const mimeType = mime.getType(extension);
 
       return {
         canceled: result.canceled,
-        filePaths: relativePath,
+        selectedFilePath,
+        attachmentName,
+        fileBase64,
+        baseName,
+        mimeType,
       };
     } catch (error) {
       console.error("open-file-dialog handler:", error);

--- a/src/main/ipcMainHandlers/openFolderDialog.cjs
+++ b/src/main/ipcMainHandlers/openFolderDialog.cjs
@@ -19,7 +19,7 @@ const openFolderDialog = () => {
         folderPaths: relativePath,
       };
     } catch (error) {
-      console.error("open-folder-dialog handler:", error);
+      console.error("open-folder-dialog handler 에러:", error);
       return {
         canceled: true,
         filePaths: "",

--- a/src/main/ipcMainHandlers/openFolderDialog.cjs
+++ b/src/main/ipcMainHandlers/openFolderDialog.cjs
@@ -1,0 +1,31 @@
+const { ipcMain, dialog } = require("electron");
+const path = require("path");
+const os = require("os");
+
+const homeDir = os.homedir();
+
+const openFolderDialog = () => {
+  ipcMain.handle("open-folder-dialog", async () => {
+    try {
+      const result = await dialog.showOpenDialog({
+        properties: ["openDirectory"],
+      });
+
+      const selectedFolderPath = result.filePaths[0];
+      const relativePath = path.relative(homeDir, selectedFolderPath);
+
+      return {
+        canceled: result.canceled,
+        folderPaths: relativePath,
+      };
+    } catch (error) {
+      console.error("open-folder-dialog handler:", error);
+      return {
+        canceled: true,
+        filePaths: "",
+      };
+    }
+  });
+};
+
+openFolderDialog();

--- a/src/main/ipcMainHandlers/replicateFile.cjs
+++ b/src/main/ipcMainHandlers/replicateFile.cjs
@@ -7,34 +7,39 @@ const { convertPath } = require("../utils/convertPath.cjs");
 
 const replicateFile = () => {
   ipcMain.handle("replicate-file", async (event, order) => {
-    if (order.action !== "복제하기") {
-      console.error(`수신받은 행동이 "복제하기"가 아닙니다.`);
-      return;
-    }
-
-    const folderPath = convertPath(order.executionPath);
-    const filePath = path.join(folderPath, order.attachmentName);
-    const baseName = path.basename(order.attachmentName);
-
-    if (!fs.existsSync(filePath)) {
-      throw new Error("해당 위치에 요청한 파일이 없습니다.");
-    }
-
-    let copyFileName = getCopyFileName(baseName);
-    let copyFilePath = path.join(folderPath, copyFileName);
-
-    while (fs.existsSync(copyFilePath)) {
-      copyFileName = getCopyFileName(copyFileName);
-      copyFilePath = path.join(folderPath, copyFileName);
-    }
-
-    fs.copyFile(filePath, copyFilePath, (error) => {
-      if (error) {
-        console.log("파일 복사 중 오류가 발생하였습니다.", error);
-      } else {
-        console.log("파일이 성공적으로 복사되었습니다.");
+    try {
+      if (order.action !== "복제하기") {
+        console.error(`수신받은 행동이 "복제하기"가 아닙니다.`);
+        return;
       }
-    });
+
+      const fullPath = path.join(order.executionPath, order.attachmentName);
+      const convertedFullPath = convertPath(fullPath);
+
+      if (!fs.existsSync(convertedFullPath)) {
+        throw new Error("해당 위치에 요청한 파일이 없습니다.");
+      }
+
+      const baseName = path.basename(order.attachmentName);
+      const folderPath = convertPath(order.executionPath);
+      let copyFileName = getCopyFileName(baseName);
+      let copyFilePath = path.join(folderPath, copyFileName);
+
+      while (fs.existsSync(copyFilePath)) {
+        copyFileName = getCopyFileName(copyFileName);
+        copyFilePath = path.join(folderPath, copyFileName);
+      }
+
+      fs.copyFile(convertedFullPath, copyFilePath, (error) => {
+        if (error) {
+          console.log("replicate-file main handler 에러:", error);
+        } else {
+          console.log("파일이 성공적으로 복사되었습니다.");
+        }
+      });
+    } catch (error) {
+      console.error("replicate-file main handler 에러:", error);
+    }
   });
 };
 

--- a/src/main/ipcMainHandlers/replicateFile.cjs
+++ b/src/main/ipcMainHandlers/replicateFile.cjs
@@ -1,0 +1,41 @@
+const { ipcMain } = require("electron");
+const path = require("path");
+const fs = require("fs");
+
+const { getCopyFileName } = require("../utils/getCopyFileName.cjs");
+const { convertPath } = require("../utils/convertPath.cjs");
+
+const replicateFile = () => {
+  ipcMain.handle("replicate-file", async (event, order) => {
+    if (order.action !== "복제하기") {
+      console.error(`수신받은 행동이 "복제하기"가 아닙니다.`);
+      return;
+    }
+
+    const folderPath = convertPath(order.executionPath);
+    const filePath = path.join(folderPath, order.attachmentName);
+    const baseName = path.basename(order.attachmentName);
+
+    if (!fs.existsSync(filePath)) {
+      throw new Error("해당 위치에 요청한 파일이 없습니다.");
+    }
+
+    let copyFileName = getCopyFileName(baseName);
+    let copyFilePath = path.join(folderPath, copyFileName);
+
+    while (fs.existsSync(copyFilePath)) {
+      copyFileName = getCopyFileName(copyFileName);
+      copyFilePath = path.join(folderPath, copyFileName);
+    }
+
+    fs.copyFile(filePath, copyFilePath, (error) => {
+      if (error) {
+        console.log("파일 복사 중 오류가 발생하였습니다.", error);
+      } else {
+        console.log("파일이 성공적으로 복사되었습니다.");
+      }
+    });
+  });
+};
+
+replicateFile();

--- a/src/main/utils/getCopyFileName.cjs
+++ b/src/main/utils/getCopyFileName.cjs
@@ -1,0 +1,21 @@
+function getCopyFileName(baseName) {
+  const baseNameArray = baseName.split(".");
+  const extension = baseNameArray.pop();
+  const fileName = baseNameArray.join(".");
+  const lastParenIndex = fileName.lastIndexOf("(");
+
+  const lastNumber = Number(
+    fileName.slice(lastParenIndex + 1, fileName.lastIndexOf(")")),
+  );
+
+  if (Number.isNaN(lastNumber) || fileName[fileName.length - 1] !== ")") {
+    return `${fileName}(1).${extension}`;
+  }
+
+  const nextCopyNumber = lastNumber + 1;
+  const copyFileName = `${fileName.slice(0, lastParenIndex)}(${nextCopyNumber}).${extension}`;
+
+  return copyFileName;
+}
+
+module.exports = { getCopyFileName };

--- a/src/main/utils/getCopyFileName.cjs
+++ b/src/main/utils/getCopyFileName.cjs
@@ -1,4 +1,4 @@
-function getCopyFileName(baseName) {
+const getCopyFileName = (baseName) => {
   const baseNameArray = baseName.split(".");
   const extension = baseNameArray.pop();
   const fileName = baseNameArray.join(".");
@@ -16,6 +16,6 @@ function getCopyFileName(baseName) {
   const copyFileName = `${fileName.slice(0, lastParenIndex)}(${nextCopyNumber}).${extension}`;
 
   return copyFileName;
-}
+};
 
 module.exports = { getCopyFileName };

--- a/src/preload/index.cjs
+++ b/src/preload/index.cjs
@@ -71,4 +71,18 @@ contextBridge.exposeInMainWorld("electronAPI", {
       console.error("Error in moveFile: ", error);
     }
   },
+  executeFile: async (order) => {
+    try {
+      await ipcRenderer.invoke("execute-file", order);
+    } catch (error) {
+      console.error("Error in executeFile: ", error);
+    }
+  },
+  replicateFile: async (order) => {
+    try {
+      await ipcRenderer.invoke("replicate-file", order);
+    } catch (error) {
+      console.error("Error in replicateFile: ", error);
+    }
+  },
 });

--- a/src/preload/index.cjs
+++ b/src/preload/index.cjs
@@ -75,7 +75,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
     try {
       await ipcRenderer.invoke("execute-file", order);
     } catch (error) {
-      console.error("Error in executeFile: ", error);
+      console.error("Error in replicateFile");
     }
   },
   replicateFile: async (order) => {

--- a/src/renderer/Components/CreatingPackage/CreatingOrder/FilePicker/index.jsx
+++ b/src/renderer/Components/CreatingPackage/CreatingOrder/FilePicker/index.jsx
@@ -9,22 +9,37 @@ function FilePicker() {
   const currentOrder = getOrder();
 
   const setFileInfo = (event) => {
-    isPickOptionDefault
-      ? updateOrder({
-          attachmentName: event.target.files[0].name,
-          attachmentFile: event.target.files[0],
-          attachmentType: "file",
-        })
-      : updateOrder({
-          attachmentName: event.target.value,
-          attachmentType: "string",
-        });
+    updateOrder({
+      attachmentName: event.target.value,
+      attachmentType: "string",
+    });
+  };
+  const openFilePicker = async () => {
+    try {
+      const { attachmentName, canceled, fileObj } =
+        await window.electronAPI.openFileDialog();
+
+      if (canceled || (currentOrder.action === "생성하기" && !fileObj)) {
+        console.error("폴더 선택이 취소되었습니다.");
+        return;
+      }
+
+      updateOrder({
+        attachmentName: attachmentName,
+        attachmentFile: fileObj,
+        attachmentType: "file",
+      });
+
+      updateOrder({ attachmentName, attachmentType: "file" });
+    } catch (error) {
+      console.error("폴더 경로를 여는 중 에러가 발생 :", error);
+    }
   };
 
   return (
     <div className="my-3">
       <label className="label-small">대상파일 선택하기</label>
-      <p className="my-1 flex justify-start space-x-4 text-gray-500">
+      <div className="my-1 flex justify-start space-x-4 text-gray-500">
         <span>선택방법 :</span>
         <label>
           <input
@@ -34,17 +49,25 @@ function FilePicker() {
           />
           파일선택기
         </label>
-        <label>
-          <input
-            type="radio"
-            checked={!isPickOptionDefault}
-            onChange={() => setIsPickOptionDefault(false)}
-          />
-          직접 입력하기
-        </label>
-      </p>
+        {currentOrder.action !== "생성하기" && (
+          <label>
+            <input
+              type="radio"
+              checked={!isPickOptionDefault}
+              onChange={() => setIsPickOptionDefault(false)}
+            />
+            직접 입력하기
+          </label>
+        )}
+      </div>
       {isPickOptionDefault ? (
-        <input type="file" className="file-input" onChange={setFileInfo} />
+        <button
+          type="button"
+          className="input-base focus:shadow-outline"
+          onClick={openFilePicker}
+        >
+          파일을 선택해 주세요.
+        </button>
       ) : (
         <input
           type="text"

--- a/src/renderer/Components/CreatingPackage/CreatingOrder/FolderPicker/index.jsx
+++ b/src/renderer/Components/CreatingPackage/CreatingOrder/FolderPicker/index.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import usePackageStore from "@renderer/store";
 
 function FolderPicker({ isOptional }) {
-  const [filePath, setFilePath] = useState("");
+  const [folderPath, setFolderPath] = useState("");
   const { updateOrder, getOrder, setClientStatus, clientStatus } =
     usePackageStore();
   const currentOrder = getOrder();
@@ -14,28 +14,27 @@ function FolderPicker({ isOptional }) {
 
   useEffect(() => {
     if (clientStatus.isSubmitted) {
-      setFilePath("");
+      setFolderPath("");
       setClientStatus({ isSubmitted: false });
     }
   }, [clientStatus.isSubmitted]);
 
   const openFolderPicker = async () => {
     try {
-      const { canceled, filePaths } = await window.electronAPI.openFileDialog();
+      const { canceled, folderPaths } =
+        await window.electronAPI.openFolderDialog();
 
       if (canceled) {
         console.error("폴더 선택이 취소되었습니다.");
       }
 
-      if (filePaths.length === 0) {
+      if (folderPaths.length === 0) {
         console.error("선택된 경로가 없습니다.");
       }
 
-      const selectedPath = filePaths;
+      setFolderPath(folderPaths);
 
-      setFilePath(selectedPath);
-
-      updateOrder({ [pathType]: selectedPath });
+      updateOrder({ [pathType]: folderPaths });
     } catch (error) {
       console.error("폴더 경로를 여는 중 에러가 발생 :", error);
     }
@@ -43,10 +42,10 @@ function FolderPicker({ isOptional }) {
 
   const appendUserPath = (event) => {
     const userDefinedPath = event.target.value;
-    updateOrder({ [pathType]: filePath + userDefinedPath });
+    updateOrder({ [pathType]: folderPath + userDefinedPath });
   };
 
-  const displayedPath = currentOrder[pathType] || filePath;
+  const displayedPath = currentOrder[pathType] || folderPath;
 
   return (
     <div className="my-3">

--- a/src/renderer/Components/CreatingPackage/PackagePreview/Order/index.jsx
+++ b/src/renderer/Components/CreatingPackage/PackagePreview/Order/index.jsx
@@ -6,6 +6,7 @@ function Order({ order, index }) {
 
   const { action, attachmentName, sourcePath, executionPath, editingName } =
     order;
+
   const handleDelete = () => {
     deleteOrder(index);
   };

--- a/src/renderer/Components/ReceivingPackage/index.jsx
+++ b/src/renderer/Components/ReceivingPackage/index.jsx
@@ -78,13 +78,13 @@ function ReceivingPackage() {
               await window.electronAPI.moveFile(order);
               break;
             case "복제하기":
-              console.log("파일을 복제합니다");
+              await window.electronAPI.replicateFile(order);
               break;
             case "수정하기":
               await window.electronAPI.editFileName(order);
               break;
             case "실행하기":
-              console.log("파일을 실행합니다");
+              await window.electronAPI.executeFile(order);
               break;
             case "삭제하기":
               await window.electronAPI.deleteFile(order);

--- a/tests/getCopyFileName.test.js
+++ b/tests/getCopyFileName.test.js
@@ -1,0 +1,39 @@
+/* eslint-disable */
+const { getCopyFileName } = require("../src/main/utils/getCopyFileName.cjs");
+
+it("파일이름 끝에 번호가 없을경우 (1)번이 붙어서 만들어져야 합니다.", () => {
+  const testFileName = "테스트 파일이름.app";
+
+  expect(getCopyFileName(testFileName)).toBe("테스트 파일이름(1).app");
+});
+
+it("파일이름 끝에 ()번호가 붙어있을 경우 해당번호에 1추가 돼서 새로 만들어져야 합니다.", () => {
+  const testFileName = "테스트 파일이름(1).app";
+
+  expect(getCopyFileName(testFileName)).toBe("테스트 파일이름(2).app");
+});
+
+it("파일이름 중간에 ()가 있을 경우 마지막에 (1)번이 붙어서 만들어져야 합니다.", () => {
+  const testFileName = "테스트(1)번째 테스트.app";
+
+  expect(getCopyFileName(testFileName)).toBe("테스트(1)번째 테스트(1).app");
+});
+
+it("파일이름 중간과 마지막에 () 있을 경우도 잘 구분해서 만들어져야 합니다.", () => {
+  const testFileName = "테스트(1)번째 테스트(3).app";
+
+  expect(getCopyFileName(testFileName)).toBe("테스트(1)번째 테스트(4).app");
+});
+
+it("파일이름 중간에 . 있을 경우도 확장자와 잘 구분해서 만들어져야 합니다.", () => {
+  const testFileName = "테스트. 파일이름.app";
+
+  expect(getCopyFileName(testFileName)).toBe("테스트. 파일이름(1).app");
+});
+
+it("복합적으로 이름 중간에 나와도 잘 구분해서 만들어져야 합니다.", () => {
+  const testFileName = "(1)(5)번째. 테스트(10).app";
+
+  expect(getCopyFileName(testFileName)).toBe("(1)(5)번째. 테스트(11).app");
+});
+/* eslint-enable */


### PR DESCRIPTION
# 칸반 명

[[APP] 📩 수신자 - 매크로 행동 실행 로직 구현 (복제, 실행) ](https://www.notion.so/startled-hamster/APP-2-3-ipcMain-ipcRenderer-07605c48aaf24d02b5bd9bfd4a39dc0c?pvs=4)

# 해당 업무 리스트

**⚠️ React 가 아닌, Node 기반에서 수행합니다. ⚠️**

- Renderer Side
    - [x]  매크로 행동 수신 후, 전달받은 테스크 모음을  각 행동별로 적절한 ipcRenderer 이벤트를 발생시킵니다.
- Main Side
    
    클라이언트 측에서 받은 매크로 행동 데이터를 기반으로 행동 수행 로직 구현 
    - [x]  복제하기 로직
        - [x]  요청한 위치에 요청한 파일 복사본을 1개 더 생성합니다.
        - [x]  복사본의 경우 파일 명은 ‘(n)’ 형태로 복사본임을 알 수 있게 붙어야 합니다.
    - [x]  실행하기 로직
        - [x]  요청한 위치의 요청한 파일을 실행합니다.
        - [ ]  확장자를 열어볼 수 있는 도구가 마련되지 않아서 열 수 없는 경우 사용자에게 알람을 줘야 합니다. -> 별도 칸반으로 옮김 ([[APP] 📩 수신자 - 경로 및 파일 처리 로직 구현](https://www.notion.so/startled-hamster/APP-239e5f9c99624b6a84d5376a7b2ef10c?pvs=4))
- 공통
- [x]  행동이 두개 이상일시 차례대로 실행되어서 꼬이지 않도록 구현합니다.
- [x]  명령에따라 경로 이동 중, 더 이상 유효한 경로가 없을 경우 행동을 멈추고 알람을 주어야 합니다.
# 상세 기술

- 수신자가 매크로 소포를 수락했을 시, 전달받은 매크로 행동을 실행하는 로직을 구현합니다.
- 수신자가 받은 매크로 소포안에 “복제하기” 행동이 있을시 지정된 폴더에 복제복을 하나더 만들어 줍니다.
    - 파일이름(n) 형식으로 만들어집니다.
- 수신자가 받은 매크로 소포안에 “실행하기” 행동이 있을시 지정된 폴더에 해당 파일을 실행시켜줍니다.

## 참고사항

- 기존 input type=”file” 일때 .app 확장자가 인식이 .zip 으로 인식되는 경우가 있어서 해당 파일 선택기를 electron node 환경으로 구현
- 파일 선택기에서 파일 선택해서 업로드를 실행할 경우 파일객체가 필요해짐으로써 readFileSync 와 mimeType, buffer Array, blobObj 를 사용해서 구현
    - mimeType을 알기위해 라이브러리 설치로 인한 아래 명령어 실행 필요
    
      ```jsx
      npm install
      ```
    
- 파일 복제할때 단순 복제명령을 실행하면 파일이 덮어씌워 져서 복제 됐는지 알 수 없는 경우가 생겨 파일 이름 뒤에 (n) 를 붙여 복사본을 생성
    - 해당 복사본 이름을 구하는 유틸 함수를 따로 만들어주었습니다.
    - 해당 테스트파일 또한 같이 만들어주었습니다.

# PR 체크 사항

## 주의 사항

- [x]  PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x]  conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x]  가장 최신 브랜치를 pull 하였습니다.
- [x]  base 브랜치명을 확인하였습니다.
- [x]  코드 컨벤션을 모두 확인하였습니다.
- [x]  브랜치명을 확인하였습니다.
- [x]  작업 중 dependency 변경사항이 있는 경우 안내해주세요!


## 리뷰 반영사항

* 변수명 수정 
* convertPath 함수 위치 변경 (마지막에 호출)
* 에러 메세지 통일
* exec 비동기 메서드 ---> execSync 동기 메서드로 변경