### PR TITLE
Feat: [APP] 즐겨찾기 저장, 불러오기 버튼 누를시 front 로직 구현

### DIFF
--- a/src/renderer/Components/App.jsx
+++ b/src/renderer/Components/App.jsx
@@ -14,17 +14,17 @@ import MyPackages from "./MyPackages";
 function App() {
   const { setClientStatus } = usePackageStore();
 
-  const hasPreviousLogin = () => {
+  const hasPreviousLoginInfo = () => {
     const refreshToken = localStorage.getItem("refreshToken");
     const jwtToken = localStorage.getItem("jwtToken");
-    const userId = localStorage.getItem("userID");
+    const userId = localStorage.getItem("userId");
     const targetId = localStorage.getItem("targetId");
 
     return refreshToken && jwtToken && userId && targetId;
   };
 
   useEffect(() => {
-    if (hasPreviousLogin()) {
+    if (hasPreviousLoginInfo()) {
       setClientStatus({ isLogin: true });
     } else {
       window.localStorage.clear();

--- a/src/renderer/Components/App.jsx
+++ b/src/renderer/Components/App.jsx
@@ -1,4 +1,7 @@
 import { Route, Routes } from "react-router-dom";
+import { useEffect } from "react";
+
+import usePackageStore from "@renderer/store";
 
 import Home from "./Home";
 import Nav from "./Nav";
@@ -7,17 +10,33 @@ import SignUp from "./SignUp";
 import ReceivingPackage from "./ReceivingPackage";
 import CreatingPackage from "./CreatingPackage";
 import MyPackages from "./MyPackages";
-import { useState } from "react";
 
 function App() {
-  const [isLogIn, setIsLogIn] = useState(false);
+  const { setClientStatus } = usePackageStore();
+
+  const hasPreviousLogin = () => {
+    const refreshToken = localStorage.getItem("refreshToken");
+    const jwtToken = localStorage.getItem("jwtToken");
+    const userId = localStorage.getItem("userID");
+    const targetId = localStorage.getItem("targetId");
+
+    return refreshToken && jwtToken && userId && targetId;
+  };
+
+  useEffect(() => {
+    if (hasPreviousLogin()) {
+      setClientStatus({ isLogin: true });
+    } else {
+      window.localStorage.clear();
+    }
+  }, []);
 
   return (
     <div className="flex min-h-screen flex-col">
-      <Nav isLogIn={isLogIn} setIsLogIn={setIsLogIn} />
+      <Nav />
       <div className="flex-grow">
         <Routes>
-          <Route path="/" element={<Home setIsLogIn={setIsLogIn} />} />
+          <Route path="/" element={<Home />} />
           <Route path="/login" element={<Login />} />
           <Route path="/signUp" element={<SignUp />} />
           <Route path="/package/new" element={<CreatingPackage />} />

--- a/src/renderer/Components/CreatingPackage/CreatingOrder/BookmarkToolbar/index.jsx
+++ b/src/renderer/Components/CreatingPackage/CreatingOrder/BookmarkToolbar/index.jsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 import usePackageStore from "@renderer/store";
 import Modal from "../../../Modal";
+import { GUIDE_MESSAGES } from "@renderer/constants/messages.js";
 
 import addingIcon from "@images/addingIcon.svg";
 import downloadIcon from "@images/downloadIcon.svg";
@@ -18,7 +19,7 @@ function BookmarkToolbar() {
 
   const userId = localStorage.getItem("userID");
   const notifyLoginRequired = () => {
-    alert("로그인 유저 전용 기능입니다.");
+    alert(GUIDE_MESSAGES.REQUIRE_LOGIN);
   };
 
   const handleAddBookmark = async () => {
@@ -27,6 +28,11 @@ function BookmarkToolbar() {
       return;
     }
     const BookmarkTarget = getOrder();
+
+    if (!validateRequiredInputs(BookmarkTarget)) {
+      alert(GUIDE_MESSAGES.BOOKMARK_REQUIREMENT);
+    }
+
     const formattedBookmarkData = {
       ...BookmarkTarget,
       attachmentType: "",
@@ -67,6 +73,11 @@ function BookmarkToolbar() {
   const applyBookmark = (index) => {
     updateOrder(bookmarks[index]);
     setIsModalOpen(false);
+  };
+
+  const validateRequiredInputs = (inputs) => {
+    const requiredField = [action, attachmentName, executionPath];
+    return requiredField.every((field) => inputs.field.length > 0);
   };
 
   return (

--- a/src/renderer/Components/CreatingPackage/CreatingOrder/BookmarkToolbar/index.jsx
+++ b/src/renderer/Components/CreatingPackage/CreatingOrder/BookmarkToolbar/index.jsx
@@ -1,19 +1,41 @@
 import axios from "axios";
+import { useState } from "react";
 
 import usePackageStore from "@renderer/store";
+import Modal from "../../../Modal";
 
 import addingIcon from "@images/addingIcon.svg";
 import downloadIcon from "@images/downloadIcon.svg";
 
 function BookmarkToolbar() {
-  const getOrder = usePackageStore((state) => state.getOrder);
-  const BookmarkTarget = getOrder();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [bookmarks, setBookMarks] = useState([]);
+  const {
+    clientStatus: { isLogin },
+    getOrder,
+    updateOrder,
+  } = usePackageStore();
 
-  const handleAddBookmark = () => {
-    // TODO: 유저아이디 받아오는 로직 추가 구현 필요
-    axios.post(
-      `${import.meta.env.VITE_SERVER_URL}/${"user-id"}/bookmark`,
-      BookmarkTarget,
+  const userId = localStorage.getItem("userID");
+  const notifyLoginRequired = () => {
+    alert("로그인 유저 전용 기능입니다.");
+  };
+
+  const handleAddBookmark = async () => {
+    if (!isLogin) {
+      notifyLoginRequired();
+      return;
+    }
+    const BookmarkTarget = getOrder();
+    const formattedBookmarkData = {
+      ...BookmarkTarget,
+      attachmentType: "",
+      attachmentUrl: "",
+    };
+
+    await axios.post(
+      `${import.meta.env.VITE_SERVER_URL}/${userId}/bookmark`,
+      formattedBookmarkData,
       {
         headers: {
           "Content-Type": "application/json",
@@ -21,29 +43,75 @@ function BookmarkToolbar() {
       },
     );
   };
+
+  const handleGetBookmark = async () => {
+    if (!isLogin) {
+      notifyLoginRequired();
+      return;
+    }
+    const BookmarkTarget = getOrder();
+    const result = await axios.post(
+      `${import.meta.env.VITE_SERVER_URL}/${userId}/bookmark`,
+      BookmarkTarget,
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+
+    setBookMarks(result);
+    setIsModalOpen(true);
+  };
+
+  const applyBookmark = (index) => {
+    updateOrder(bookmarks[index]);
+    setIsModalOpen(false);
+  };
+
   return (
     <>
+      {bookmarks.length > 0 && (
+        <Modal isOpen={isModalOpen}>
+          {bookmarks.map((bookmark, index) => (
+            <button
+              key={bookmark.attachmentName}
+              className="button-base-blue"
+              onClick={() => {
+                applyBookmark(index);
+              }}
+            >
+              {bookmark.action}
+            </button>
+          ))}
+          <button
+            className="button-yellow-square"
+            onClick={() => {
+              setIsModalOpen(false);
+            }}
+          >
+            닫기
+          </button>
+        </Modal>
+      )}
       <span className="label-large">즐겨찾기</span>
       <div className="flex flex-row justify-around py-1">
         <div className="flex flex-row">
-          <span className="block content-center px-3 text-sm text-gray-500">
-            추가하기
-          </span>
+          <span className="text-sm-gray-centered">추가하기</span>
           <button
             type="button"
-            className="inline-flex h-10 w-10 items-center justify-center rounded-full border-none bg-blue-600 outline-none hover:bg-blue-700 active:bg-blue-600"
+            className="button-blue-round"
             onClick={handleAddBookmark}
           >
             <img src={addingIcon} alt="adding Icon" />
           </button>
         </div>
         <div className="flex flex-row">
-          <span className="block content-center px-3 text-sm text-gray-500">
-            가져오기
-          </span>
+          <span className="text-sm-gray-centered">가져오기</span>
           <button
             type="button"
-            className="inline-flex h-10 w-10 items-center justify-center rounded border-none bg-yellow-400 outline-none hover:bg-yellow-600 active:bg-yellow-500"
+            className="button-yellow-square"
+            onClick={handleGetBookmark}
           >
             <img src={downloadIcon} alt="download Icon" />
           </button>

--- a/src/renderer/Components/CreatingPackage/CreatingOrder/BookmarkToolbar/index.jsx
+++ b/src/renderer/Components/CreatingPackage/CreatingOrder/BookmarkToolbar/index.jsx
@@ -17,7 +17,7 @@ function BookmarkToolbar() {
     updateOrder,
   } = usePackageStore();
 
-  const userId = localStorage.getItem("userID");
+  const userId = localStorage.getItem("userId");
   const notifyLoginRequired = () => {
     alert(GUIDE_MESSAGES.REQUIRE_LOGIN);
   };
@@ -39,15 +39,19 @@ function BookmarkToolbar() {
       attachmentUrl: "",
     };
 
-    await axios.post(
-      `${import.meta.env.VITE_SERVER_URL}/${userId}/bookmark`,
-      formattedBookmarkData,
-      {
-        headers: {
-          "Content-Type": "application/json",
+    try {
+      await axios.post(
+        `${import.meta.env.VITE_SERVER_URL}/${userId}/bookmark`,
+        formattedBookmarkData,
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
         },
-      },
-    );
+      );
+    } catch (error) {
+      console.error("즐겨찾기 등록하는 중 에러발생 :", error);
+    }
   };
 
   const handleGetBookmark = async () => {
@@ -56,17 +60,23 @@ function BookmarkToolbar() {
       return;
     }
     const BookmarkTarget = getOrder();
-    const result = await axios.post(
-      `${import.meta.env.VITE_SERVER_URL}/${userId}/bookmark`,
-      BookmarkTarget,
-      {
-        headers: {
-          "Content-Type": "application/json",
-        },
-      },
-    );
+    let result;
 
-    setBookMarks(result);
+    try {
+      result = await axios.post(
+        `${import.meta.env.VITE_SERVER_URL}/${userId}/bookmark`,
+        BookmarkTarget,
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        },
+      );
+    } catch (error) {
+      console.error("즐겨찾기 가져오는 중 에러발생 :", error);
+    }
+
+    setBookMarks(result.data);
     setIsModalOpen(true);
   };
 
@@ -80,6 +90,7 @@ function BookmarkToolbar() {
     return requiredField.every((field) => inputs.field.length > 0);
   };
 
+  //TODO: 모달창 안의 버튼의 키값을 유효한 값으로 넣어주시기 바랍니다.
   return (
     <>
       {bookmarks.length > 0 && (

--- a/src/renderer/Components/CreatingPackage/PackagePreview/index.jsx
+++ b/src/renderer/Components/CreatingPackage/PackagePreview/index.jsx
@@ -95,7 +95,7 @@ function PackagePreview() {
       try {
         if (error.response.data.error === "Token expired") {
           const userRefreshToken = window.localStorage.getItem("refreshToken");
-          const userId = window.localStorage.getItem("userID");
+          const userId = window.localStorage.getItem("userId");
           const authorization = "Bearer " + userRefreshToken;
 
           const { jwtToken, refreshToken } = await axios.post(

--- a/src/renderer/Components/Home/index.jsx
+++ b/src/renderer/Components/Home/index.jsx
@@ -1,13 +1,15 @@
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useEffect } from "react";
-import PropTypes from "prop-types";
 import axios from "axios";
 
-import DeliLogo from "../../assets/images/logo.png";
+import usePackageStore from "@renderer/store";
 
-function Home({ setIsLogIn }) {
-  const [searchParams, setSearchParams] = useSearchParams();
+import DeliLogo from "@renderer/assets/images/logo.png";
+
+function Home() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const { setClientStatus } = usePackageStore();
 
   useEffect(() => {
     const getJwtToken = async () => {
@@ -28,14 +30,14 @@ function Home({ setIsLogIn }) {
         // TODO: 추후 에러관련 처리
         throw new Error(error);
       } finally {
-        setIsLogIn(true);
+        setClientStatus({ isLogin: true });
       }
     };
 
     if (searchParams.get("code")) {
       getJwtToken();
     }
-  }, [searchParams, setIsLogIn]);
+  }, [searchParams]);
 
   const navigateToReceivingPage = () => {
     navigate("/package/receiving");
@@ -67,9 +69,5 @@ function Home({ setIsLogIn }) {
     </div>
   );
 }
-
-Home.propTypes = {
-  setIsLogIn: PropTypes.func.isRequired,
-};
 
 export default Home;

--- a/src/renderer/Components/Modal/index.jsx
+++ b/src/renderer/Components/Modal/index.jsx
@@ -4,8 +4,8 @@ function Modal({ isOpen, children }) {
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
-      <div className="relative flex min-w-[300px] items-center justify-center rounded-lg bg-white p-6 shadow-lg">
+    <div className="fixed inset-0 z-10 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="relative z-20 flex min-w-[300px] items-center justify-center rounded-lg bg-white p-6 shadow-lg">
         <div className="flex-col items-center justify-center">{children}</div>
       </div>
     </div>

--- a/src/renderer/Components/MyPackages/mockData.json
+++ b/src/renderer/Components/MyPackages/mockData.json
@@ -153,7 +153,44 @@
       "__v": 0
     }
   ],
-  "bookmark": [],
+  "bookmark": [
+    {
+      "action": "생성하기",
+      "attachmentName": "image (2).png",
+      "attachmentType": "file",
+      "attachmentUrl": "https://fakeSAWSUrl2",
+      "sourcePath": "",
+      "executionPath": "C:\\Users\\userK\\Downloads",
+      "editingName": "",
+      "_id": {
+        "$oid": "fakeMongooseObjectId"
+      },
+      "createdAt": {
+        "$date": "2024-08-20T16:38:47.895Z"
+      },
+      "updatedAt": {
+        "$date": "2024-08-20T16:38:47.895Z"
+      }
+    },
+    {
+      "action": "이동하기",
+      "attachmentName": "dogpung.gif",
+      "attachmentType": "file",
+      "attachmentUrl": "",
+      "sourcePath": "C:\\Users\\userK\\Pictures",
+      "executionPath": "C:\\Users\\userK\\Documents",
+      "editingName": "",
+      "_id": {
+        "$oid": "fakeMongooseObjectId"
+      },
+      "createdAt": {
+        "$date": "2024-08-20T16:38:47.896Z"
+      },
+      "updatedAt": {
+        "$date": "2024-08-20T16:38:47.896Z"
+      }
+    }
+  ],
   "loginType": "google",
   "refreshToken": "fakeToken",
   "createdAt": {

--- a/src/renderer/Components/Nav/index.jsx
+++ b/src/renderer/Components/Nav/index.jsx
@@ -5,8 +5,10 @@ import usePackageStore from "@renderer/store";
 import DeliLogo from "../../assets/images/logo.png";
 
 function Nav() {
-  const { clientStatus, setClientStatus } = usePackageStore();
-  const { isLogin } = clientStatus;
+  const {
+    clientStatus: { isLogin },
+    setClientStatus,
+  } = usePackageStore();
 
   const handleLogOut = async () => {
     if (!isLogin) return;
@@ -54,13 +56,11 @@ function Nav() {
           </Link>
         </div>
         <div>
-          <Link
-            //TODO: 추후 내 소포함 페이지 연결 && 백엔드 verify 함수 사용
-            to="/myPackages"
-            className="button-white-border mr-6"
-          >
-            내 소포함
-          </Link>
+          {isLogin && (
+            <Link to="/myPackages" className="button-white-border mr-6">
+              내 소포함
+            </Link>
+          )}
           <Link
             to={isLogin ? "/" : "/login"}
             onClick={handleLogOut}

--- a/src/renderer/Components/Nav/index.jsx
+++ b/src/renderer/Components/Nav/index.jsx
@@ -1,26 +1,26 @@
 import { Link } from "react-router-dom";
 import axios from "axios";
-import PropTypes from "prop-types";
+import usePackageStore from "@renderer/store";
 
 import DeliLogo from "../../assets/images/logo.png";
 
-function Nav({ isLogIn, setIsLogIn }) {
+function Nav() {
+  const { clientStatus, setClientStatus } = usePackageStore();
+  const { isLogin } = clientStatus;
+
   const handleLogOut = async () => {
+    if (!isLogin) return;
+
     try {
       const target_id = window.localStorage.getItem("targetId");
 
       await axios.post(
         `${import.meta.env.VITE_SERVER_URL}/auth/sign-out/kakao`,
-        {
-          target_id,
-        },
+        { target_id },
       );
 
-      window.localStorage.removeItem("jwtToken");
-      window.localStorage.removeItem("refreshToken");
-      window.localStorage.removeItem("targetId");
-      window.localStorage.removeItem("userId");
-      setIsLogIn(false);
+      window.localStorage.clear();
+      setClientStatus({ isLogin: false });
     } catch (error) {
       // TODO: 추후 에러처리 관련 구현
       alert(error.message);
@@ -43,22 +43,13 @@ function Nav({ isLogIn, setIsLogIn }) {
       </div>
       <div className="block w-full flex-grow lg:flex lg:w-auto lg:items-center">
         <div className="text-sm lg:flex-grow">
-          <Link
-            to="/"
-            className="mr-4 mt-4 block text-teal-200 hover:text-white lg:mt-0 lg:inline-block"
-          >
+          <Link to="/" className="text-teal-hover-white mr-4">
             소개
           </Link>
-          <Link
-            to="/package/new"
-            className="mr-4 mt-4 block text-teal-200 hover:text-white lg:mt-0 lg:inline-block"
-          >
+          <Link to="/package/new" className="text-teal-hover-white mr-4">
             보내기
           </Link>
-          <Link
-            to="/package/receiving"
-            className="mt-4 block text-teal-200 hover:text-white lg:mt-0 lg:inline-block"
-          >
+          <Link to="/package/receiving" className="text-teal-hover-white">
             받기
           </Link>
         </div>
@@ -66,26 +57,21 @@ function Nav({ isLogIn, setIsLogIn }) {
           <Link
             //TODO: 추후 내 소포함 페이지 연결 && 백엔드 verify 함수 사용
             to="/myPackages"
-            className="mr-6 mt-4 inline-block rounded border border-white px-4 py-2 text-sm leading-none text-white hover:border-transparent hover:bg-white hover:text-teal-500 lg:mt-0"
+            className="button-white-border mr-6"
           >
             내 소포함
           </Link>
           <Link
-            to={isLogIn ? "/" : "/login"}
-            onClick={isLogIn && handleLogOut}
-            className="mt-4 inline-block rounded border border-white px-4 py-2 text-sm leading-none text-white hover:border-transparent hover:bg-white hover:text-teal-500 lg:mt-0"
+            to={isLogin ? "/" : "/login"}
+            onClick={handleLogOut}
+            className="button-white-border"
           >
-            {isLogIn ? "로그아웃" : "로그인"}
+            {isLogin ? "로그아웃" : "로그인"}
           </Link>
         </div>
       </div>
     </nav>
   );
 }
-
-Nav.propTypes = {
-  setIsLogIn: PropTypes.func.isRequired,
-  isLogIn: PropTypes.bool.isRequired,
-};
 
 export default Nav;

--- a/src/renderer/Components/ReceivingPackage/index.jsx
+++ b/src/renderer/Components/ReceivingPackage/index.jsx
@@ -7,7 +7,7 @@ import NumberInput from "./NumberInput";
 import { SERIAL_NUMBER_LENGTH } from "../../constants/config";
 
 function ReceivingPackage() {
-  const [isModalOpen, setIsModalOpen] = useState();
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const [inputNumbers, setInputNumbers] = useState(
     Array(SERIAL_NUMBER_LENGTH).fill(""),
   );
@@ -121,7 +121,7 @@ function ReceivingPackage() {
             .map((_, index) => (
               <NumberInput
                 key={index}
-                onKeyDownFunc={() => {
+                onKeyDownFunc={(event) => {
                   validateNumber(event);
                   updateInputNumbers(event, index);
                 }}

--- a/src/renderer/Components/shared/style.css
+++ b/src/renderer/Components/shared/style.css
@@ -26,6 +26,14 @@
   @apply my-3 w-full rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700;
 }
 
+.button-blue-round {
+  @apply inline-flex h-10 w-10 items-center justify-center rounded-full border-none bg-blue-600 outline-none hover:bg-blue-700 active:bg-blue-600;
+}
+
+.button-yellow-square {
+  @apply inline-flex h-10 w-10 items-center justify-center rounded border-none bg-yellow-400 outline-none hover:bg-yellow-600 active:bg-yellow-500;
+}
+
 .button-white-border {
   @apply mt-4 inline-block rounded border border-white px-4 py-2 text-sm leading-none text-white hover:border-transparent hover:bg-white hover:text-teal-500 lg:mt-0;
 }
@@ -40,6 +48,10 @@
 
 .text-xs-red {
   @apply mt-2 text-xs text-red-400;
+}
+
+.text-sm-gray-centered {
+  @apply block content-center px-3 text-sm text-gray-500;
 }
 
 .text-base-gray {

--- a/src/renderer/Components/shared/style.css
+++ b/src/renderer/Components/shared/style.css
@@ -26,6 +26,10 @@
   @apply my-3 w-full rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700;
 }
 
+.button-white-border {
+  @apply mt-4 inline-block rounded border border-white px-4 py-2 text-sm leading-none text-white hover:border-transparent hover:bg-white hover:text-teal-500 lg:mt-0;
+}
+
 .file-input {
   @apply w-full cursor-pointer rounded border bg-white text-sm font-semibold text-gray-400 file:mr-4 file:cursor-pointer file:border-0 file:px-4 file:py-3 file:text-gray-500 file:hover:bg-gray-200;
 }
@@ -44,4 +48,8 @@
 
 .text-block-blue {
   @apply min-h-10 min-w-8 rounded bg-sky-300 px-4 py-2 text-sm;
+}
+
+.text-teal-hover-white {
+  @apply mt-4 block text-teal-200 hover:text-white lg:mt-0 lg:inline-block;
 }

--- a/src/renderer/constants/messages.js
+++ b/src/renderer/constants/messages.js
@@ -7,4 +7,6 @@ export const VALIDATION_MESSAGES = {
 export const GUIDE_MESSAGES = {
   COMPRESSION_NOTICE:
     "여러개의 파일이 필요할 경우 하나의 파일로 압축하여 사용해 주세요.",
+  BOOKMARK_REQUIREMENT: "필수 항목을 작성해 주세요",
+  REQUIRE_LOGIN: "로그인 유저 전용 기능입니다.",
 };

--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -3,6 +3,7 @@ import { create } from "zustand";
 const createClientStatusSlice = (set, get) => ({
   clientStatus: {
     isSubmitted: false,
+    isLogin: false,
   },
   setClientStatus: (setValue) =>
     set((state) => ({


### PR DESCRIPTION
# 칸반 명

🔗 [[APP] 즐겨찾기 저장, 불러오기 버튼 누를시 front 로직 구현](https://www.notion.so/startled-hamster/APP-front-abda16a4b0fd4b91aec867763db8c5d8?pvs=4)


# 해당 업무 리스트

**⚠️ 해당 기능은 ‘로그인을 한’ 유저에게만 표시됩니다. ⚠️** 

### **로그인 관련 선처리 업무**

- [x]  앱 진입시 로컬에 로그인 정보가 남아있다면, 로그인 한 상태로 인식하게 합니다.
    
    (참고: local storage 안에 로그인 관련 정보는 총 4개 )
    
    - [x]  4개가 전부 있어야 로그인 상태로 인정합니다.
    - [x]  하나라도 부족할 경우, 로컬의 로그인 정보를 클리어 해주고 로그아웃 상태를 유지합니다.
    - [x]  useState 로 관리되고 있는 isLogin을 중앙상태관리자(store)로 관리합니다.

### **본 칸반 업무**

- [x]  즐겨찾기 저장 버튼을 누를시 올바르게 저장 되어야 합니다.
    - [x]  필요 항목이 비어있을시 저장되지 않아야하며, 유저에게 에러메세지를 표시해주어야합니다.
- [x]  즐겨찾기 불러오기를 누를시 올바르게 즐겨찾기 목록이 불러와져야 합니다.
  - [x]  필요 항목이 비어있을시 저장되지 않아야하며,
  - [x]  빈 항목이 있을 시 유저에게 에러메세지를 표시해주어야합니다.
- [x]  불러온 즐겨찾기 목록을 모달로 보여주어야 합니다.

### 기타 에러핸들링

- [x]  한 페이지 안에 여러 컴포넌트가 있을 시, 모달창이 제대로 보이지 않는 현상 수정.(z값 부여)

    <수정 전>
<img width="1325" alt="스크린샷 2024-08-21 오후 8 13 26" src="https://github.com/user-attachments/assets/54825d7d-5a10-48ae-997b-559436128141">

    <수정 후>
<img width="1312" alt="스크린샷 2024-08-21 오후 8 13 07" src="https://github.com/user-attachments/assets/1f94eca0-506b-4ca6-ab2e-74d367e2dbcf">

    
# 상세 기술

- 즐겨찾기 저장 버튼을 누를시 Axios API를 이용해 해당 유저 데이터베이스에 저장을 요청합니다.
- 즐겨찾기 불러오기 버튼 누를시 Axios API를 이용해 해당 유저 데이터베이스에 저장된 즐겨찾기 목록을 불러와줍니다.

# 참고사항

- isLogin 이라는 상태값이 전역상태 관리자로 관리되게 되었습니다. 
- bookmarkToolBar 의 일부 스타일이 클래스화 되었습니다. 
- 북마크 테스트를 위한 목업데이터 업데이트가 있었습니다.

# PR 체크 사항

## 주의 사항

- [x]  PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x]  conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x]  가장 최신 브랜치를 pull 하였습니다.
- [x]  base 브랜치명을 확인하였습니다.
- [x]  코드 컨벤션을 모두 확인하였습니다.
- [x]  브랜치명을 확인하였습니다.
- [x]  작업 중 dependency 변경사항이 있는 경우 안내해주세요!


## 리뷰 반영사항

- 함수명 개선 (이전에 로그인 한적 있는지 체킹)
- 데이터를 올바르게 가져올 수 있도록 접근 경로 수정
