### PR TITLE
Feat: 즐겨찾기 저장, 불러오기 버튼 누를시 front 로직 수정

### DIFF
--- a/src/renderer/Components/CreatingPackage/CreatingOrder/BookmarkToolbar/index.jsx
+++ b/src/renderer/Components/CreatingPackage/CreatingOrder/BookmarkToolbar/index.jsx
@@ -31,14 +31,16 @@ function BookmarkToolbar() {
   const handleAddBookmark = async () => {
     if (!isLogin) {
       notifyLoginRequired();
+      setIsInfoModalOpen(true);
       return;
     }
     const BookmarkTarget = getOrder();
 
     if (!validateRequiredInputs(BookmarkTarget)) {
       setIsError(true);
-
       setInfoMessage(GUIDE_MESSAGES.BOOKMARK_REQUIREMENT);
+      setIsInfoModalOpen(true);
+      return;
     }
 
     const formattedBookmarkData = {
@@ -62,14 +64,16 @@ function BookmarkToolbar() {
       setInfoMessage(response.data.message);
       setIsInfoModalOpen(true);
     } catch (error) {
-      console.error(
-        "즐겨찾기 등록하는 중 에러발생 :",
-        error.response.data.message,
-      );
-      setInfoMessage(
-        "즐겨찾기 등록하는 중 에러발생",
-        error.response.data.message,
-      );
+      if (error.response) {
+        console.error(
+          "즐겨찾기 등록하는 중 에러발생 :",
+          error.response.data.message,
+        );
+        setInfoMessage("에러발생: " + error.response.data.message);
+      } else {
+        console.error("응답을 받지 못하였습니다");
+        setInfoMessage("일시적 서버에러입니다. 잠시후 다시 시도해주세요");
+      }
 
       setIsError(true);
       setIsInfoModalOpen(true);
@@ -95,14 +99,19 @@ function BookmarkToolbar() {
       setBookMarks(response.data.bookmarkList);
       setIsModalOpen(true);
     } catch (error) {
-      console.error(
-        "즐겨찾기 가져오는 중 에러발생 :",
-        error.response.data.message,
-      );
-      setInfoMessage(
-        "즐겨찾기 가져오는 중 에러발생 :",
-        error.response.data.message,
-      );
+      if (error.response) {
+        console.error(
+          "즐겨찾기 가져오는 중 에러발생 :",
+          error.response.data.message,
+        );
+        setInfoMessage("에러발생: " + error.response.data.message);
+      } else {
+        console.error("응답을 받지 못하였습니다");
+        setInfoMessage("일시적 서버에러입니다. 잠시후 다시 시도해주세요");
+      }
+
+      setIsError(true);
+      setIsInfoModalOpen(true);
     }
   };
 
@@ -114,6 +123,11 @@ function BookmarkToolbar() {
   const validateRequiredInputs = (inputs) => {
     const requiredField = ["action", "attachmentName", "executionPath"];
     return requiredField.every((field) => inputs[field].length > 0);
+  };
+
+  const closeModal = () => {
+    setIsError(false);
+    setIsInfoModalOpen(false);
   };
 
   return (
@@ -142,20 +156,10 @@ function BookmarkToolbar() {
         </Modal>
       )}
       {
-        <InfoModal isOpen={isInfoModalOpen}>
-          <h2 className="mb-4 text-xl font-semibold">DELIORDER</h2>
+        <InfoModal isOpen={isInfoModalOpen} onClose={closeModal}>
           <p className={`font-bold ${isError ? "text-red-600" : ""}`}>
             {infoMessage}
           </p>
-          <button
-            className="focus:shadow-outline mt-4 rounded-md bg-blue-400 px-4 py-2 text-center font-bold text-white hover:bg-blue-500"
-            onClick={() => {
-              setIsError(false);
-              setIsInfoModalOpen(false);
-            }}
-          >
-            닫기
-          </button>
         </InfoModal>
       }
       <span className="label-large">즐겨찾기</span>

--- a/src/renderer/Components/CreatingPackage/CreatingOrder/BookmarkToolbar/index.jsx
+++ b/src/renderer/Components/CreatingPackage/CreatingOrder/BookmarkToolbar/index.jsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 import usePackageStore from "@renderer/store";
 import Modal from "../../../Modal";
+import InfoModal from "../../../InfoModal";
 import { GUIDE_MESSAGES } from "@renderer/constants/messages.js";
 
 import addingIcon from "@images/addingIcon.svg";
@@ -11,6 +12,10 @@ import downloadIcon from "@images/downloadIcon.svg";
 function BookmarkToolbar() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [bookmarks, setBookMarks] = useState([]);
+  const [isInfoModalOpen, setIsInfoModalOpen] = useState(false);
+  const [infoMessage, setInfoMessage] = useState("");
+  const [isError, setIsError] = useState(false);
+
   const {
     clientStatus: { isLogin },
     getOrder,
@@ -19,7 +24,8 @@ function BookmarkToolbar() {
 
   const userId = localStorage.getItem("userId");
   const notifyLoginRequired = () => {
-    alert(GUIDE_MESSAGES.REQUIRE_LOGIN);
+    setIsError(true);
+    setInfoMessage(GUIDE_MESSAGES.REQUIRE_LOGIN);
   };
 
   const handleAddBookmark = async () => {
@@ -30,27 +36,43 @@ function BookmarkToolbar() {
     const BookmarkTarget = getOrder();
 
     if (!validateRequiredInputs(BookmarkTarget)) {
-      alert(GUIDE_MESSAGES.BOOKMARK_REQUIREMENT);
+      setIsError(true);
+
+      setInfoMessage(GUIDE_MESSAGES.BOOKMARK_REQUIREMENT);
     }
 
     const formattedBookmarkData = {
       ...BookmarkTarget,
       attachmentType: "",
+      attachmentFile: "",
       attachmentUrl: "",
     };
 
     try {
-      await axios.post(
-        `${import.meta.env.VITE_SERVER_URL}/${userId}/bookmark`,
-        formattedBookmarkData,
+      const response = await axios.post(
+        `${import.meta.env.VITE_SERVER_URL}/users/${userId}/bookmark`,
+        { action: formattedBookmarkData },
         {
           headers: {
             "Content-Type": "application/json",
           },
         },
       );
+
+      setInfoMessage(response.data.message);
+      setIsInfoModalOpen(true);
     } catch (error) {
-      console.error("즐겨찾기 등록하는 중 에러발생 :", error);
+      console.error(
+        "즐겨찾기 등록하는 중 에러발생 :",
+        error.response.data.message,
+      );
+      setInfoMessage(
+        "즐겨찾기 등록하는 중 에러발생",
+        error.response.data.message,
+      );
+
+      setIsError(true);
+      setIsInfoModalOpen(true);
     }
   };
 
@@ -59,25 +81,29 @@ function BookmarkToolbar() {
       notifyLoginRequired();
       return;
     }
-    const BookmarkTarget = getOrder();
-    let result;
 
     try {
-      result = await axios.post(
-        `${import.meta.env.VITE_SERVER_URL}/${userId}/bookmark`,
-        BookmarkTarget,
+      const response = await axios.get(
+        `${import.meta.env.VITE_SERVER_URL}/users/${userId}/bookmark`,
         {
           headers: {
             "Content-Type": "application/json",
           },
         },
       );
-    } catch (error) {
-      console.error("즐겨찾기 가져오는 중 에러발생 :", error);
-    }
 
-    setBookMarks(result.data);
-    setIsModalOpen(true);
+      setBookMarks(response.data.bookmarkList);
+      setIsModalOpen(true);
+    } catch (error) {
+      console.error(
+        "즐겨찾기 가져오는 중 에러발생 :",
+        error.response.data.message,
+      );
+      setInfoMessage(
+        "즐겨찾기 가져오는 중 에러발생 :",
+        error.response.data.message,
+      );
+    }
   };
 
   const applyBookmark = (index) => {
@@ -86,18 +112,17 @@ function BookmarkToolbar() {
   };
 
   const validateRequiredInputs = (inputs) => {
-    const requiredField = [action, attachmentName, executionPath];
-    return requiredField.every((field) => inputs.field.length > 0);
+    const requiredField = ["action", "attachmentName", "executionPath"];
+    return requiredField.every((field) => inputs[field].length > 0);
   };
 
-  //TODO: 모달창 안의 버튼의 키값을 유효한 값으로 넣어주시기 바랍니다.
   return (
     <>
       {bookmarks.length > 0 && (
         <Modal isOpen={isModalOpen}>
           {bookmarks.map((bookmark, index) => (
             <button
-              key={bookmark.attachmentName}
+              key={bookmark.createdAt}
               className="button-base-blue"
               onClick={() => {
                 applyBookmark(index);
@@ -116,6 +141,23 @@ function BookmarkToolbar() {
           </button>
         </Modal>
       )}
+      {
+        <InfoModal isOpen={isInfoModalOpen}>
+          <h2 className="mb-4 text-xl font-semibold">DELIORDER</h2>
+          <p className={`font-bold ${isError ? "text-red-600" : ""}`}>
+            {infoMessage}
+          </p>
+          <button
+            className="focus:shadow-outline mt-4 rounded-md bg-blue-400 px-4 py-2 text-center font-bold text-white hover:bg-blue-500"
+            onClick={() => {
+              setIsError(false);
+              setIsInfoModalOpen(false);
+            }}
+          >
+            닫기
+          </button>
+        </InfoModal>
+      }
       <span className="label-large">즐겨찾기</span>
       <div className="flex flex-row justify-around py-1">
         <div className="flex flex-row">

--- a/src/renderer/Components/InfoModal/index.jsx
+++ b/src/renderer/Components/InfoModal/index.jsx
@@ -1,12 +1,18 @@
 import PropTypes from "prop-types";
 
-function InfoModal({ isOpen, children }) {
+function InfoModal({ isOpen, onClose, children }) {
   if (!isOpen) return null;
 
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center bg-black bg-opacity-50">
-      <div className="relative z-20 flex min-w-[300px] items-center justify-center rounded-lg bg-white p-6 shadow-lg">
+      <div className="relative z-20 flex min-w-[300px] flex-col items-center justify-center rounded-lg bg-white p-6 shadow-lg">
         <div className="flex-col items-center justify-center">{children}</div>
+        <button
+          className="focus:shadow-outline mt-4 rounded-md bg-blue-400 px-4 py-2 text-center font-bold text-white hover:bg-blue-500"
+          onClick={onClose}
+        >
+          닫기
+        </button>
       </div>
     </div>
   );
@@ -14,6 +20,7 @@ function InfoModal({ isOpen, children }) {
 
 InfoModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
   children: PropTypes.node,
 };
 

--- a/src/renderer/Components/InfoModal/index.jsx
+++ b/src/renderer/Components/InfoModal/index.jsx
@@ -1,0 +1,20 @@
+import PropTypes from "prop-types";
+
+function InfoModal({ isOpen, children }) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-10 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="relative z-20 flex min-w-[300px] items-center justify-center rounded-lg bg-white p-6 shadow-lg">
+        <div className="flex-col items-center justify-center">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+InfoModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  children: PropTypes.node,
+};
+
+export default InfoModal;


### PR DESCRIPTION
# 칸반 명

🔗 [[APP] 즐겨찾기 저장, 불러오기 버튼 누를시 front 로직 구현](https://www.notion.so/startled-hamster/APP-front-abda16a4b0fd4b91aec867763db8c5d8?pvs=4)


# 해당 업무 리스트

**⚠️ 해당 기능은 ‘로그인을 한’ 유저에게만 표시됩니다. ⚠️** 

### **본 칸반 업무**

- [x]  즐겨찾기 저장 버튼을 누를시 올바르게 저장 되어야 합니다.
    - [x]  필요 항목이 비어있을시 저장되지 않아야하며, 유저에게 에러메세지를 표시해주어야합니다.
- [x]  즐겨찾기 불러오기를 누를시 올바르게 즐겨찾기 목록이 불러와져야 합니다.
  - [x]  필요 항목이 비어있을시 저장되지 않아야하며,
  - [x]  빈 항목이 있을 시 유저에게 에러메세지를 표시해주어야합니다.
- [x]  불러온 즐겨찾기 목록을 모달로 보여주어야 합니다.


# 상세 기술

- **큰 변경사항은 없으며, 서버작업과 더불어 정상적인 작동이 이루어 질 수 있도록 구현하였습니다.**

# 참고사항

- 안내메세지 등을 표시할 수 있는 안내모달을 별도 컴포넌트로 분리하여 작성하였습니다.

# PR 체크 사항

## 주의 사항

- [x]  PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x]  conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x]  가장 최신 브랜치를 pull 하였습니다.
- [x]  base 브랜치명을 확인하였습니다.
- [x]  코드 컨벤션을 모두 확인하였습니다.
- [x]  브랜치명을 확인하였습니다.
- [x]  작업 중 dependency 변경사항이 있는 경우 안내해주세요!


## 리뷰 반영사항

- 코드스타일 수정
- InfoModal 컴포넌트 내 기본 닫기버튼 추가
- 기타 에러 처리 보완
