### PR TITLE
Feat: 소포 업로드 완료 이후, 생성된 일련번호 화면에 표시하는 front 로직 구현

### DIFF
--- a/src/main/index.cjs
+++ b/src/main/index.cjs
@@ -15,8 +15,13 @@ require("./ipcMainHandlers/editFileName.cjs");
 const createWindow = () => {
   const BASE_URL = process.env.VITE_BASE_URL;
   const win = new BrowserWindow({
-    width: 1200,
+    width: 1280,
     height: 800,
+    autoHideMenuBar: true,
+    resizable: false,
+    backgroundColor: "#DBEAFE",
+    icon: path.join(__dirname, "../renderer/assets/images/logo.png"),
+    roundedCorners: true,
     webPreferences: {
       preload: path.join(__dirname, "../preload/index.cjs"),
       contextIsolation: true,

--- a/src/renderer/Components/CreatingPackage/PackagePreview/index.jsx
+++ b/src/renderer/Components/CreatingPackage/PackagePreview/index.jsx
@@ -73,7 +73,7 @@ function PackagePreview() {
           });
 
           const signedUrl = await getSignedUrl(s3Client, getCommand, {
-            expiresIn: 600000,
+            expiresIn: 600,
           });
 
           file.attachmentUrl = signedUrl;


### PR DESCRIPTION
# 칸반 명

🔗[[APP]  송신자 - 소포 업로드 완료 이후, 생성된 일련번호 와 링크 화면에 표현 front 로직](https://www.notion.so/startled-hamster/APP-front-c6d36485149f4254bde26366101c80cf)  


# 구현화면
![image](https://github.com/user-attachments/assets/f545b4a1-801c-4d4d-a00e-378ace33050a)

# 해당 업무 리스트

- [x]  일련번호 옆 버튼 누를 시 일련번호가 복사 되어야 합니다.
- 제한시간
    - [x]  제한 시간이 지나면 파일을 다운받지 못하도록 합니다.
        - [x]  시간 초과시 시간 초과 관련 에러메세지를 사용자에게 보여줍니다.
- [x]  링크 옆 버튼 누를 시 링크가 복사 되어야 합니다. → 링크 구현 칸반 따로 추가
- [x]  닫기 버튼을 누를시 모달창이 닫혀야 합니다.

## 칸반 외 추가 처리사항
- `BrowserWindow`의 일부 설정을 변경하여 사용자에게 표시되는 화면을 개선하였습니다
  -  메뉴바 자동숨김, 기본배경색설정, 아이콘설정, 창크기변경 불가 속성 등
  - 다만, 일부 설정은 특정 os에만 적용되니 참고해주시기 바라겠습니다

# 상세 기술
- navigator.clipboard.writeText() 메서드를 통해 복사 버튼 기능을 구현하였습니다

# PR 체크 사항

## 주의 사항

- [x]  PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x]  conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x]  가장 최신 브랜치를 pull 하였습니다.
- [x]  base 브랜치명을 확인하였습니다.
- [x]  코드 컨벤션을 모두 확인하였습니다.
- [x]  브랜치명을 확인하였습니다.
- [x]  작업 중 dependency 변경사항이 있는 경우 안내해주세요!


## 리뷰 반영사항

-
