### PR TITLE
Feat: 이메일 가입, 로그인 관련 에러, 엣지케이스 처리 - 프론트 로직

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "concurrently": "^8.2.2",
         "dotenv": "^16.4.5",
         "firebase": "^10.13.0",
+        "iconv-lite": "^0.6.3",
         "mime": "^4.0.4",
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
@@ -7961,6 +7962,18 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/idb": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
@@ -12247,6 +12260,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.23.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-router-dom": "^6.26.0",
         "trash": "^9.0.0",
         "wait-on": "^7.2.0",
+        "yauzl": "^3.1.3",
         "zustand": "^4.5.5"
       },
       "devDependencies": {
@@ -5580,7 +5581,6 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -7135,6 +7135,17 @@
       },
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -11255,7 +11266,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -13609,14 +13619,16 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.1.3.tgz",
+      "integrity": "sha512-JCCdmlJJWv7L0q/KylOekyRaUrdEoUxWkWVcgorosTROCFWiS9p2NNPE9Yb91ak7b1N5SxAZEliWpspbZccivw==",
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-router-dom": "^6.26.0",
     "trash": "^9.0.0",
     "wait-on": "^7.2.0",
+    "yauzl": "^3.1.3",
     "zustand": "^4.5.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "concurrently": "^8.2.2",
     "dotenv": "^16.4.5",
     "firebase": "^10.13.0",
+    "iconv-lite": "^0.6.3",
     "mime": "^4.0.4",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",

--- a/src/main/index.cjs
+++ b/src/main/index.cjs
@@ -11,6 +11,7 @@ require("./ipcMainHandlers/downloadFile.cjs");
 require("./ipcMainHandlers/moveFile.cjs");
 require("./ipcMainHandlers/deleteFile.cjs");
 require("./ipcMainHandlers/editFileName.cjs");
+require("./ipcMainHandlers/unzipFile.cjs");
 
 const createWindow = () => {
   const BASE_URL = process.env.VITE_BASE_URL;

--- a/src/main/ipcMainHandlers/downloadFile.cjs
+++ b/src/main/ipcMainHandlers/downloadFile.cjs
@@ -23,20 +23,23 @@ const downloadFile = () => {
         fs.mkdirSync(convertedFolderPath, { recursive: true });
       }
 
-      https
-        .get(order.attachmentUrl, (response) => {
-          response.pipe(file);
+      const result = await new Promise((resolve, reject) => {
+        https
+          .get(order.attachmentUrl, (response) => {
+            response.pipe(file);
 
-          file.on("finish", () => {
-            file.close();
+            file.on("finish", () => {
+              file.close(resolve);
+            });
+          })
+          .on("error", (error) => {
+            fs.unlink(convertedFullPath);
+            console.error("파일 다운로드 중 오류 발생", error);
+            throw new Error("파일 다운로드 중 오류 발생");
           });
-        })
-        .on("error", (error) => {
-          fs.unlink(convertedFullPath);
-          console.error("파일 다운로드 중 오류 발생", error);
-        });
+      });
 
-      return "생성 성공";
+      return result;
     } catch (error) {
       console.error("download-file main handler 에러:", error);
 

--- a/src/main/ipcMainHandlers/openFileDialog.cjs
+++ b/src/main/ipcMainHandlers/openFileDialog.cjs
@@ -38,8 +38,8 @@ const openFileDialog = () => {
       return {
         canceled: result.canceled,
         selectedFilePath,
-        attachmentName,
-        fileBase64,
+        attachmentName: attachmentName.normalize("NFC"),
+        fileBase64: fileBase64.normalize("NFC"),
         baseName,
         mimeType,
       };

--- a/src/main/ipcMainHandlers/openFileDialog.cjs
+++ b/src/main/ipcMainHandlers/openFileDialog.cjs
@@ -3,21 +3,33 @@ const path = require("path");
 const fs = require("fs");
 
 const openFileDialog = () => {
-  ipcMain.handle("open-file-dialog", async () => {
+  ipcMain.handle("open-file-dialog", async (event, action) => {
     try {
-      const mime = (await import("mime")).default;
       const result = await dialog.showOpenDialog({
         properties: ["openFile"],
+        ...(action === "압축해제하기" && {
+          filters: [
+            {
+              name: "ZIP Files",
+              extensions: ["zip"],
+            },
+          ],
+        }),
       });
       const selectedFilePath = result.filePaths[0];
       const { base: attachmentName, ext: extension } =
         path.parse(selectedFilePath);
-      const selectedFileStat = fs.statSync(selectedFilePath);
 
-      if (selectedFileStat.isDirectory()) {
+      if (action === "압축해제하기" && extension !== ".zip") {
+        console.error("해당 파일이 zip 파일이 아닙니다");
+        return;
+      }
+
+      if (action !== "생성하기") {
         return { attachmentName, canceled: result.canceled };
       }
 
+      const mime = (await import("mime")).default;
       const fileBuffer = fs.readFileSync(selectedFilePath);
       const baseName = path.basename(selectedFilePath);
       const fileBase64 = fileBuffer.toString("base64");

--- a/src/main/ipcMainHandlers/unzipFile.cjs
+++ b/src/main/ipcMainHandlers/unzipFile.cjs
@@ -1,0 +1,94 @@
+const { ipcMain } = require("electron");
+const path = require("path");
+const fs = require("fs");
+const yauzl = require("yauzl");
+
+const { getCopyFileName } = require("../utils/getCopyFileName.cjs");
+const { convertPath } = require("../utils/convertPath.cjs");
+
+const unzipFile = () => {
+  ipcMain.handle("unzip-file", async (event, order) => {
+    if (order.action !== "압축해제하기") {
+      console.error(`수신받은 행동이 "압축해제하기"가 아닙니다.`);
+      return;
+    }
+
+    const fullPath = path.join(order.executionPath, order.attachmentName);
+    const convertedFullPath = convertPath(fullPath);
+
+    if (!fs.existsSync(convertedFullPath)) {
+      throw new Error("해당 위치에 요청한 파일 또는 폴더가 없습니다.");
+    }
+
+    let { name } = path.parse(convertedFullPath);
+    let newFullPath = path.join(order.executionPath, name);
+    let newConvertedFullPath = convertPath(newFullPath);
+
+    while (fs.existsSync(newConvertedFullPath)) {
+      name = getCopyFileName(name);
+
+      newFullPath = path.join(order.executionPath, name);
+      newConvertedFullPath = convertPath(newFullPath);
+    }
+
+    try {
+      const result = await new Promise((resolve, reject) => {
+        yauzl.open(
+          convertedFullPath,
+          { lazyEntries: true, decodeStrings: false },
+          (error, zipFile) => {
+            if (error) {
+              console.error("압축해제에 실패했습니다.");
+              reject("압축해제 실패");
+              return;
+            }
+
+            zipFile.readEntry();
+            zipFile.on("entry", (entry) => {
+              const fileNameBuffer = Buffer.from(entry.fileName, "binary");
+              const decodedFileName = fileNameBuffer.toString("utf-8");
+              const filePath = path.join(newConvertedFullPath, decodedFileName);
+
+              if (/\/$/.test(decodedFileName)) {
+                fs.mkdirSync(filePath, { recursive: true });
+                zipFile.readEntry();
+                return;
+              }
+
+              if (decodedFileName.startsWith("__MACOSX/")) {
+                zipFile.readEntry();
+                return;
+              }
+
+              zipFile.openReadStream(entry, (error, readStream) => {
+                if (error) {
+                  console.error("압축해제에 실패했습니다.");
+                  reject("압축해제 실패");
+                  return;
+                }
+
+                fs.mkdirSync(path.dirname(filePath), {
+                  recursive: true,
+                });
+
+                readStream.pipe(fs.createWriteStream(filePath));
+                readStream.on("end", () => zipFile.readEntry());
+              });
+            });
+
+            zipFile.on("end", () => {
+              resolve("압축해제 성공");
+            });
+          },
+        );
+      });
+
+      return result;
+    } catch (error) {
+      console.error("unzip-file main handler 에러: ", error);
+      return "압축해제 실패";
+    }
+  });
+};
+
+unzipFile();

--- a/src/preload/index.cjs
+++ b/src/preload/index.cjs
@@ -12,12 +12,12 @@ contextBridge.exposeInMainWorld("electronAPI", {
       };
     }
   },
-  openFileDialog: async () => {
+  openFileDialog: async (action) => {
     try {
       const { canceled, attachmentName, fileBase64, mimeType, baseName } =
-        await ipcRenderer.invoke("open-file-dialog");
+        await ipcRenderer.invoke("open-file-dialog", action);
 
-      if (!fileBase64 || !mimeType) {
+      if (action !== "생성하기") {
         return { attachmentName, canceled };
       }
 

--- a/src/preload/index.cjs
+++ b/src/preload/index.cjs
@@ -83,4 +83,11 @@ contextBridge.exposeInMainWorld("electronAPI", {
       console.error("Error in replicateFile: ", error);
     }
   },
+  unzipFile: async (order) => {
+    try {
+      return await ipcRenderer.invoke("unzip-file", order);
+    } catch (error) {
+      console.error("Error in unzipFile: ", error);
+    }
+  },
 });

--- a/src/renderer/Components/CreatingPackage/CreatingOrder/ActionPicker/index.jsx
+++ b/src/renderer/Components/CreatingPackage/CreatingOrder/ActionPicker/index.jsx
@@ -1,14 +1,16 @@
 import usePackageStore from "@renderer/store";
 
 function ActionPicker() {
-  const { updateOrder, getOrder } = usePackageStore();
+  const { updateOrder, getOrder, clearOrder } = usePackageStore();
   const { setClientStatus } = usePackageStore();
   const currentOrder = getOrder();
 
   const handleActionChange = (event) => {
     const selectedAction = event.target.value;
 
-    if (selectedAction === "생성하기") {
+    clearOrder();
+
+    if (selectedAction === "생성하기" || selectedAction === "압축해제하기") {
       setClientStatus({ isPickFile: true, isUsingFilePicker: true });
     }
 
@@ -31,6 +33,7 @@ function ActionPicker() {
         <option>수정하기</option>
         <option>실행하기</option>
         <option>삭제하기</option>
+        <option>압축해제하기</option>
       </select>
     </>
   );

--- a/src/renderer/Components/CreatingPackage/CreatingOrder/FilePicker/index.jsx
+++ b/src/renderer/Components/CreatingPackage/CreatingOrder/FilePicker/index.jsx
@@ -17,7 +17,7 @@ function FilePicker() {
   const openFilePicker = async () => {
     try {
       const { attachmentName, canceled, fileObj } =
-        await window.electronAPI.openFileDialog();
+        await window.electronAPI.openFileDialog(currentOrder.action);
 
       if (canceled || (currentOrder.action === "생성하기" && !fileObj)) {
         console.error("폴더 선택이 취소되었습니다.");
@@ -29,8 +29,6 @@ function FilePicker() {
         attachmentFile: fileObj,
         attachmentType: "file",
       });
-
-      updateOrder({ attachmentName, attachmentType: "file" });
     } catch (error) {
       console.error("폴더 경로를 여는 중 에러가 발생 :", error);
     }
@@ -48,16 +46,17 @@ function FilePicker() {
           />
           파일
         </label>
-        {currentOrder.action !== "생성하기" && (
-          <label>
-            <input
-              type="radio"
-              checked={!isPickFile}
-              onChange={() => setClientStatus({ isPickFile: false })}
-            />
-            폴더
-          </label>
-        )}
+        {currentOrder.action !== "생성하기" &&
+          currentOrder.action !== "압축해제하기" && (
+            <label>
+              <input
+                type="radio"
+                checked={!isPickFile}
+                onChange={() => setClientStatus({ isPickFile: false })}
+              />
+              폴더
+            </label>
+          )}
       </label>
       {isPickFile && (
         <>
@@ -71,16 +70,19 @@ function FilePicker() {
               />
               파일선택기
             </label>
-            {currentOrder.action !== "생성하기" && (
-              <label>
-                <input
-                  type="radio"
-                  checked={!isUsingFilePicker}
-                  onChange={() => setClientStatus({ isUsingFilePicker: false })}
-                />
-                직접 입력하기
-              </label>
-            )}
+            {currentOrder.action !== "생성하기" &&
+              currentOrder.action !== "압축해제하기" && (
+                <label>
+                  <input
+                    type="radio"
+                    checked={!isUsingFilePicker}
+                    onChange={() =>
+                      setClientStatus({ isUsingFilePicker: false })
+                    }
+                  />
+                  직접 입력하기
+                </label>
+              )}
           </div>
           {isUsingFilePicker ? (
             <button

--- a/src/renderer/Components/CreatingPackage/PackagePreview/index.jsx
+++ b/src/renderer/Components/CreatingPackage/PackagePreview/index.jsx
@@ -48,6 +48,10 @@ function PackagePreview() {
         (action) => action.action === "생성하기",
       );
 
+      if (fileList.length === 0) {
+        setIsLoading(false);
+        return;
+      }
       // TODO:: console.error 관련 사용자에게 직접 표시되도록 개선 필요
       if (!fileList.every((action) => action.attachmentType === "file")) {
         setIsLoading(false);
@@ -92,7 +96,10 @@ function PackagePreview() {
         (action) => action.action === "생성하기",
       );
 
-      if (!fileList.every((action) => action.attachmentType === "file")) {
+      if (
+        fileList.length === 0 ||
+        !fileList.every((action) => action.attachmentType === "file")
+      ) {
         setIsLoading(false);
         throw new Error("파일이 선택되지 않았습니다.");
       }

--- a/src/renderer/Components/Home/index.jsx
+++ b/src/renderer/Components/Home/index.jsx
@@ -3,10 +3,10 @@ import { useEffect } from "react";
 import { signInWithCustomToken } from "firebase/auth";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
-import { auth } from "../../../../firebase";
+import { auth } from "@renderer/firebase";
 import usePackageStore from "@renderer/store";
 
-import { GUIDE_MESSAGES } from "../../constants/messages";
+import { GUIDE_MESSAGES } from "@renderer/constants/messages";
 import DeliLogo from "@renderer/assets/images/logo.png";
 
 function Home() {

--- a/src/renderer/Components/Home/index.jsx
+++ b/src/renderer/Components/Home/index.jsx
@@ -3,15 +3,21 @@ import { useEffect } from "react";
 import { signInWithCustomToken } from "firebase/auth";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
-import { auth } from "@renderer/firebase";
+import { auth } from "../../../../firebase";
 import usePackageStore from "@renderer/store";
 
+import { GUIDE_MESSAGES } from "../../constants/messages";
 import DeliLogo from "@renderer/assets/images/logo.png";
 
 function Home() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const { setClientStatus } = usePackageStore();
+  const { setClientStatus, openInfoModal, setInfoMessage } = usePackageStore();
+
+  const notifyInfoMessage = (message) => {
+    setInfoMessage(message);
+    openInfoModal();
+  };
 
   useEffect(() => {
     const getJwtToken = async () => {
@@ -44,8 +50,8 @@ function Home() {
         setClientStatus({ isLogin: true });
         navigate("/");
       } catch (error) {
-        // TODO: 추후 에러관련 처리
-        throw new Error(error);
+        console.errors("카카오 로그인 실패: ", error);
+        notifyInfoMessage(GUIDE_MESSAGES.SERVER_ERROR_TRY_AGAIN);
       }
     };
 

--- a/src/renderer/Components/Login/index.jsx
+++ b/src/renderer/Components/Login/index.jsx
@@ -9,9 +9,10 @@ import {
   signInWithEmailAndPassword,
 } from "firebase/auth";
 
-import { auth } from "../../firebase";
+import { auth } from "../../../../firebase";
 import usePackageStore from "@renderer/store";
 
+import { GUIDE_MESSAGES, SIGN_IN_ALERT } from "../../constants/messages";
 import googleLogo from "../../assets/images/googleLogo.svg";
 import kakaoLogo from "../../assets/images/kakaoLogo.svg";
 
@@ -21,12 +22,18 @@ function Login() {
 
   const [emailValue, setEmailValue] = useState("");
   const [passwordValue, setPasswordValue] = useState("");
+  const { openInfoModal, setInfoMessage } = usePackageStore();
 
   useEffect(() => {
     if (window.Kakao && !window.Kakao.isInitialized()) {
       window.Kakao.init(import.meta.env.VITE_KAKAO_KEY);
     }
   }, []);
+
+  const notifyInfoMessage = (message) => {
+    setInfoMessage(message);
+    openInfoModal();
+  };
 
   const handleEmailLogin = async (event) => {
     event.preventDefault();
@@ -64,6 +71,11 @@ function Login() {
       navigate("/");
     } catch (error) {
       console.error("이메일 로그인 실패: ", error);
+      if (error.code === "auth/invalid-credential") {
+        notifyInfoMessage(SIGN_IN_ALERT.CHECK_ID_OR_PASSWORD);
+      } else {
+        notifyInfoMessage(GUIDE_MESSAGES.SERVER_ERROR_TRY_AGAIN);
+      }
     }
   };
 
@@ -98,7 +110,12 @@ function Login() {
       setClientStatus({ isLogin: true });
       navigate("/");
     } catch (error) {
-      console.error("구글 로그인 실패", error);
+      console.error("구글 로그인 실패: ", error);
+      if (error.code === "auth/invalid-credential") {
+        notifyInfoMessage(SIGN_IN_ALERT.CHECK_ID_OR_PASSWORD);
+      } else {
+        notifyInfoMessage(GUIDE_MESSAGES.SERVER_ERROR_TRY_AGAIN);
+      }
     }
   };
   const handleKakaoLogin = async () => {
@@ -115,7 +132,8 @@ function Login() {
         },
       );
     } catch (error) {
-      console.error("카카오 로그인 실패:", error);
+      console.error("카카오 로그인 실패: ", error);
+      notifyInfoMessage(GUIDE_MESSAGES.SERVER_ERROR_TRY_AGAIN);
     }
   };
 

--- a/src/renderer/Components/Login/index.jsx
+++ b/src/renderer/Components/Login/index.jsx
@@ -9,7 +9,7 @@ import {
   signInWithEmailAndPassword,
 } from "firebase/auth";
 
-import { auth } from "../../../../firebase";
+import { auth } from "@renderer/firebase";
 import usePackageStore from "@renderer/store";
 
 import { GUIDE_MESSAGES, SIGN_IN_ALERT } from "../../constants/messages";
@@ -73,6 +73,12 @@ function Login() {
       console.error("이메일 로그인 실패: ", error);
       if (error.code === "auth/invalid-credential") {
         notifyInfoMessage(SIGN_IN_ALERT.CHECK_ID_OR_PASSWORD);
+      } else if (
+        error.response &&
+        error.response.status >= 400 &&
+        error.response.status < 500
+      ) {
+        notifyInfoMessage(SIGN_IN_ALERT.INVALID_REQUEST);
       } else {
         notifyInfoMessage(GUIDE_MESSAGES.SERVER_ERROR_TRY_AGAIN);
       }

--- a/src/renderer/Components/Login/index.jsx
+++ b/src/renderer/Components/Login/index.jsx
@@ -40,7 +40,7 @@ function Login() {
       const firebaseIdToken = await userCredential.user.getIdToken();
 
       const response = await axios.post(
-        `${import.meta.env.VITE_SERVER_URL}/auth/sign-in/local`,
+        `${import.meta.env.VITE_SERVER_URL}/auth/sign-in/email`,
         { firebaseIdToken },
         {
           headers: {

--- a/src/renderer/Components/Modal/InfoModal.jsx
+++ b/src/renderer/Components/Modal/InfoModal.jsx
@@ -7,7 +7,7 @@ function InfoModal() {
 
   return (
     <Modal title="알림" isOpen={infoModal.isOpen} onClose={closeInfoModal}>
-      <p className="mt-2 text-xs">{infoModal.message}</p>
+      <div className="mt-2 text-xs">{infoModal.message}</div>
     </Modal>
   );
 }

--- a/src/renderer/Components/Nav/index.jsx
+++ b/src/renderer/Components/Nav/index.jsx
@@ -5,7 +5,8 @@ import usePackageStore from "@renderer/store";
 import { getAuth, signOut } from "firebase/auth";
 
 import DeliLogo from "../../assets/images/logo.png";
-import { GUIDE_MESSAGES } from "../../constants/messages";
+import { GUIDE_MESSAGES, SIGN_OUT_ALERT } from "@renderer/constants/messages";
+
 function Nav() {
   const {
     clientStatus: { isLogin },
@@ -35,7 +36,16 @@ function Nav() {
         setClientStatus({ isLogin: false });
       } catch (error) {
         console.error("카카오 로그아웃 실패: ", error);
-        notifyInfoMessage(GUIDE_MESSAGES.SERVER_ERROR_TRY_AGAIN);
+        console.error("이메일 로그인 실패: ", error);
+        if (
+          error.response &&
+          error.response.status >= 400 &&
+          error.response.status < 500
+        ) {
+          notifyInfoMessage(SIGN_OUT_ALERT.INVALID_REQUEST);
+        } else {
+          notifyInfoMessage(GUIDE_MESSAGES.SERVER_ERROR_TRY_AGAIN);
+        }
       }
     } else {
       try {

--- a/src/renderer/Components/ReceivingPackage/ProcessConfirm/index.jsx
+++ b/src/renderer/Components/ReceivingPackage/ProcessConfirm/index.jsx
@@ -30,28 +30,37 @@ function ProcessConfirm({ orders, closeModal }) {
 
   const handleProcessPackage = async (receivedPackage) => {
     try {
-      const results = await Promise.all(
-        receivedPackage.map(async (order) => {
-          switch (order.action) {
-            case "생성하기":
-              return await window.electronAPI.downloadFile(order);
-            case "이동하기":
-              return await window.electronAPI.moveFile(order);
-            case "복제하기":
-              return await window.electronAPI.replicateFile(order);
-            case "수정하기":
-              return await window.electronAPI.editFileName(order);
-            case "실행하기":
-              return await window.electronAPI.executeFile(order);
-            case "삭제하기":
-              return await window.electronAPI.deleteFile(order);
-            case "압축해제하기":
-              return await window.electronAPI.unzipFile(order);
-            default:
-              return "알 수 없는 작업입니다";
-          }
-        }),
-      );
+      const results = [];
+
+      for (const order of receivedPackage) {
+        let result;
+        switch (order.action) {
+          case "생성하기":
+            result = await window.electronAPI.downloadFile(order);
+            break;
+          case "이동하기":
+            result = await window.electronAPI.moveFile(order);
+            break;
+          case "복제하기":
+            result = await window.electronAPI.replicateFile(order);
+            break;
+          case "수정하기":
+            result = await window.electronAPI.editFileName(order);
+            break;
+          case "실행하기":
+            result = await window.electronAPI.executeFile(order);
+            break;
+          case "삭제하기":
+            result = await window.electronAPI.deleteFile(order);
+            break;
+          case "압축해제하기":
+            result = await window.electronAPI.unzipFile(order);
+            break;
+          default:
+            result = "알 수 없는 작업입니다";
+        }
+        results.push(result);
+      }
 
       setProcessResults(results);
       openResultModal();

--- a/src/renderer/Components/ReceivingPackage/ProcessConfirm/index.jsx
+++ b/src/renderer/Components/ReceivingPackage/ProcessConfirm/index.jsx
@@ -45,6 +45,8 @@ function ProcessConfirm({ orders, closeModal }) {
               return await window.electronAPI.executeFile(order);
             case "삭제하기":
               return await window.electronAPI.deleteFile(order);
+            case "압축해제하기":
+              return await window.electronAPI.unzipFile(order);
             default:
               return "알 수 없는 작업입니다";
           }

--- a/src/renderer/Components/SignUp/index.jsx
+++ b/src/renderer/Components/SignUp/index.jsx
@@ -172,7 +172,6 @@ function SignUp() {
             className="focus:shadow-outline h-12 w-4/12 rounded-r bg-blue-400 px-4 py-2 font-bold text-white hover:bg-blue-500"
             type="button"
             onClick={handleEmailValidate}
-            //TODO: 추후 데이터베이스 연결 또는 firebase를 통해 아이디 중복 확인 로직 구현 필요
           >
             중복확인
           </button>

--- a/src/renderer/Components/SignUp/index.jsx
+++ b/src/renderer/Components/SignUp/index.jsx
@@ -72,54 +72,42 @@ function SignUp() {
       return;
     }
 
-    if (!validatePassword(passwordValue, passwordCheckValue).valid) {
-      const passwordErrorList = validatePassword(
-        passwordValue,
-        passwordCheckValue,
-      ).errors;
+    const passwordValidationResult = validatePassword(
+      passwordValue,
+      passwordCheckValue,
+    );
+    if (!passwordValidationResult.valid) {
+      const passwordErrorList = passwordValidationResult.errors;
       notifyInfoMessage(
         <>
           {passwordErrorList.map((errorMessage, index) => {
-            let errorComponent;
+            let errorText;
+
             switch (errorMessage) {
               case "isLongEnough":
-                errorComponent = (
-                  <div key={index}>{SIGN_UP_ALERT.NOT_LONG_ENOUGH}</div>
-                );
+                errorText = SIGN_UP_ALERT.NOT_LONG_ENOUGH;
                 break;
               case "hasLetter":
-                errorComponent = (
-                  <div key={index}>{SIGN_UP_ALERT.DO_NOT_HAS_LETTER}</div>
-                );
+                errorText = SIGN_UP_ALERT.DO_NOT_HAS_LETTER;
                 break;
               case "hasNumber":
-                errorComponent = (
-                  <div key={index}>{SIGN_UP_ALERT.DO_NOT_HAS_NUMBER}</div>
-                );
+                errorText = SIGN_UP_ALERT.DO_NOT_HAS_NUMBER;
                 break;
               case "hasSpecialChar":
-                errorComponent = (
-                  <div key={index}>{SIGN_UP_ALERT.DO_NOT_HAS_SPECIAL_CHAR}</div>
-                );
+                errorText = SIGN_UP_ALERT.DO_NOT_HAS_SPECIAL_CHAR;
                 break;
               case "hasNoWhitespace":
-                errorComponent = (
-                  <div key={index}>
-                    {SIGN_UP_ALERT.DO_NOT_HAS_NO_WHITESPACE}
-                  </div>
-                );
+                errorText = SIGN_UP_ALERT.DO_NOT_HAS_NO_WHITESPACE;
                 break;
               case "hasSameValue":
-                errorComponent = (
-                  <div key={index}>{SIGN_UP_ALERT.DO_NOT_HAS_SAME_VALUE}</div>
-                );
+                errorText = SIGN_UP_ALERT.DO_NOT_HAS_SAME_VALUE;
                 break;
               default:
-                errorComponent = <div key={index}>{errorMessage}</div>;
+                errorText = errorMessage;
                 break;
             }
 
-            return errorComponent;
+            return <div key={index}>{errorText}</div>;
           })}
         </>,
       );

--- a/src/renderer/constants/messages.js
+++ b/src/renderer/constants/messages.js
@@ -4,10 +4,31 @@ export const VALIDATION_MESSAGES = {
   MAX_ORDER_LIMIT: `조합 최대 갯수는 ${MAXIMUM_ORDER_NUMBER}개 입니다.`,
 };
 
+export const SIGN_UP_ALERT = {
+  EMAIL_VERIFICATION_SUCCESS: "이메일 중복 검사가 완료되었습니다.",
+  EMAIL_ALREADY_REGISTERED: "이미 가입된 이메일 주소입니다.",
+  INVALID_EMAIL_FORMAT: "유효하지 않은 이메일 형식입니다.",
+  EMAIL_VERIFICATION_REQUIRED: "이메일 중복 확인이 필요합니다.",
+  AGREEMENT_REQUIRED: "개인정보 처리방침에 동의하셔야 가입이 가능합니다.",
+  NOT_LONG_ENOUGH: "비밀번호는 최소 8자 이상이어야 합니다.",
+  DO_NOT_HAS_LETTER: "비밀번호에는 최소 하나의 영문자가 포함되어야 합니다.",
+  DO_NOT_HAS_NUMBER: "비밀번호에는 최소 하나의 숫자가 포함되어야 합니다.",
+  DO_NOT_HAS_SPECIAL_CHAR:
+    "비밀번호에는 최소 하나의 특수문자가 포함되어야 합니다.",
+  DO_NOT_HAS_NO_WHITESPACE: "비밀번호에는 공백이 포함될 수 없습니다.",
+  DO_NOT_HAS_SAME_VALUE: "비밀번호와 비밀번호 확인이 일치해야 합니다.",
+};
+
+export const SIGN_IN_ALERT = {
+  CHECK_ID_OR_PASSWORD: "아이디 또는 비밀번호를 다시 확인해주세요",
+};
+
 export const GUIDE_MESSAGES = {
   COMPRESSION_NOTICE:
     "여러개의 파일이 필요할 경우 하나의 파일로 압축하여 사용해 주세요.",
   BOOKMARK_REQUIREMENT: "필수 항목을 작성해 주세요",
   REQUIRE_LOGIN: "로그인 유저 전용 기능입니다.",
   CONFIRMATION: "내용을 확인하고 진행 하시겠습니까?",
+  SERVER_ERROR_TRY_AGAIN:
+    "서버에 일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주시기 바랍니다.",
 };

--- a/src/renderer/constants/messages.js
+++ b/src/renderer/constants/messages.js
@@ -21,6 +21,11 @@ export const SIGN_UP_ALERT = {
 
 export const SIGN_IN_ALERT = {
   CHECK_ID_OR_PASSWORD: "아이디 또는 비밀번호를 다시 확인해주세요",
+  INVALID_REQUEST: "비정상적인 접근입니다",
+};
+
+export const SIGN_OUT_ALERT = {
+  INVALID_REQUEST: "비정상적인 접근입니다",
 };
 
 export const GUIDE_MESSAGES = {

--- a/src/renderer/utils/refreshToken.js
+++ b/src/renderer/utils/refreshToken.js
@@ -7,24 +7,25 @@ const refreshToken = async () => {
       "deliOrderRefreshToken",
     );
     const authorization = "Bearer " + deliOrderRefreshToken;
-    const { newDeliOrderToken, newDeliOrderRefreshToken } = await axios.post(
-      `${import.meta.env.VITE_SERVER_URL}/auth/refresh/kakao`,
-      { deliOrderRefreshToken, deliOrderUserId },
-      {
-        headers: {
-          "Content-Type": "application/json",
-          authorization,
+    if (deliOrderUserId && deliOrderRefreshToken) {
+      const { newDeliOrderToken, newDeliOrderRefreshToken } = await axios.post(
+        `${import.meta.env.VITE_SERVER_URL}/auth/token/refresh`,
+        { deliOrderRefreshToken, deliOrderUserId },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            authorization,
+          },
         },
-      },
-    );
-
-    window.localStorage.setItem("deliOrderToken", newDeliOrderToken);
-    window.localStorage.setItem(
-      "deliOrderRefreshToken",
-      newDeliOrderRefreshToken,
-    );
+      );
+      window.localStorage.setItem("deliOrderToken", newDeliOrderToken);
+      window.localStorage.setItem(
+        "deliOrderRefreshToken",
+        newDeliOrderRefreshToken,
+      );
+    }
   } catch (error) {
-    console.error("토큰 재발급 중 오류 발생", error);
+    console.error("토큰 재발급 불가", error);
     window.localStorage.clear();
     window.location.href = "/login";
   }

--- a/src/renderer/utils/refreshToken.js
+++ b/src/renderer/utils/refreshToken.js
@@ -7,6 +7,7 @@ const refreshToken = async () => {
       "deliOrderRefreshToken",
     );
     const authorization = "Bearer " + deliOrderRefreshToken;
+
     if (deliOrderUserId && deliOrderRefreshToken) {
       const { newDeliOrderToken, newDeliOrderRefreshToken } = await axios.post(
         `${import.meta.env.VITE_SERVER_URL}/auth/token/refresh`,
@@ -18,6 +19,7 @@ const refreshToken = async () => {
           },
         },
       );
+
       window.localStorage.setItem("deliOrderToken", newDeliOrderToken);
       window.localStorage.setItem(
         "deliOrderRefreshToken",

--- a/src/renderer/utils/refreshToken.js
+++ b/src/renderer/utils/refreshToken.js
@@ -2,12 +2,14 @@ import axios from "axios";
 
 const refreshToken = async () => {
   try {
-    const userRefreshToken = window.localStorage.getItem("refreshToken");
-    const userId = window.localStorage.getItem("userId");
-    const authorization = "Bearer " + userRefreshToken;
-    const { jwtToken, refreshToken } = await axios.post(
+    const deliOrderUserId = window.localStorage.getItem("deliOrderUserId");
+    const deliOrderRefreshToken = window.localStorage.getItem(
+      "deliOrderRefreshToken",
+    );
+    const authorization = "Bearer " + deliOrderRefreshToken;
+    const { newDeliOrderToken, newDeliOrderRefreshToken } = await axios.post(
       `${import.meta.env.VITE_SERVER_URL}/auth/refresh/kakao`,
-      { userId },
+      { deliOrderRefreshToken, deliOrderUserId },
       {
         headers: {
           "Content-Type": "application/json",
@@ -16,13 +18,15 @@ const refreshToken = async () => {
       },
     );
 
-    if (refreshToken) {
-      localStorage.setItem("refreshToken", refreshToken);
-    }
-
-    localStorage.setItem("jwtToken", jwtToken);
+    window.localStorage.setItem("deliOrderToken", newDeliOrderToken);
+    window.localStorage.setItem(
+      "deliOrderRefreshToken",
+      newDeliOrderRefreshToken,
+    );
   } catch (error) {
     console.error("토큰 재발급 중 오류 발생", error);
+    window.localStorage.clear();
+    window.location.href = "/login";
   }
 };
 

--- a/src/renderer/utils/validate.js
+++ b/src/renderer/utils/validate.js
@@ -1,0 +1,24 @@
+export const validateEmail = (email) => {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email);
+};
+
+export const validatePassword = (password, passwordCheck) => {
+  const minLength = 8;
+  const validationResults = {
+    isLongEnough: password.length >= minLength,
+    hasLetter: /[a-zA-Z]/.test(password),
+    hasNumber: /[0-9]/.test(password),
+    hasSpecialChar: /[!"#$%&'()*+,\-./:;<=>?@[\]^_`{|}~]/.test(password),
+    hasNoWhitespace: !/\s/.test(password),
+    hasSameValue: password === passwordCheck,
+  };
+
+  const failedList = Object.keys(validationResults).filter(
+    (key) => !validationResults[key],
+  );
+
+  return failedList.length > 0
+    ? { valid: false, errors: failedList }
+    : { valid: true };
+};


### PR DESCRIPTION
# 칸반 명

🔗[[APP] 이메일 가입, 로그인 관련 에러, 엣지케이스 처리-프론트](https://www.notion.so/startled-hamster/5be754c5d84e4491b52d52b93b2624f9?p=0fe57ea432e64f13bcb8ebff3a9760ab&pm=s)


# 해당 업무 리스트

### 가입하기 관련

- 아이디
    - [x]  아이디가 유효한 이메일 형식인지 확인해야합니다
    - [x]  아이디가 중복이 아닌지 확인해야합니다
        - [x]  중복검사완료 이후 아이디 input창에 변화가 있으면 중복검사결과를 false로 변화시켜야합니다.
- 비밀번호
    - [x]  비밀번호가 최소한의 유효성을 통과하는지 확인해야합니다.
        - [x]  유효성 조건: 8자이상, 영문, 숫자, 특문 1개 이상 포함
    - [x]  비밀번호 칸과 비밀번호 확인 칸이 같은 값을 가지고있는지 확인해야합니다.
- 기타
    - [x]  개인정보약관에 동의하여야 가입이 가능합니다.
    - [x]  아이디, 비밀번호, 개인정보약관동의여부 순서 여부 순서로 에러 메세지를 표시해줘야합니다.
- [x]  위 유효성 조건들을 모두 통과해야 파이어베이스 및 서버에 관련 정보를 제출할 수 있습니다
- [x]  가입 진행 관련하여 오류가 있다면 모달창등으로 관련 가입 오류의 사유를 사용자에게 알려줘야합니다.

### 로그인 관련

- 아이디
    - [x]  아이디가 유효한 이메일 형식인지 확인해야합니다
        - [x]  유효한 아이디 형식이 아닙니다 에러메세지표시
- 비밀번호
    - [x]  아이디와 비밀번호 조합이 유효한지 확인해야합니다
        - [x]  아이디 또는 비밀번호가 일치하지 않습니다 에러메세지표시
        - [x]  가입하지 않은 회원입니다 에러메세지표시
- [x]  로그인 진행 관련하여 오류가 있다면 모달창등으로 관련 가입 오류의 사유를 사용자에게 알려줘야합니다.  

### 로그아웃 관련

- [x]  전역 로그인상태가 true인상태에서만 진행이 가능합니다.
- [x]  (카카오) 로그인한 상태라면 서버로 로컬스토리지에 저장된 유저 데이터베이스아이디와 로그인타입을 보내 추후 처리한 뒤 정상 응답이 오면 로컬스토리지를 비운 뒤 전역 로그인상태를 false로 변경합니다
- [x]  (파이어베이스) firebaseSDK 메서드를 사용한뒤 로컬스토리지를 비운뒤 전역 로그인상태를 false로 변경합니다
- [x]  로그아웃 시도 도중 오류가 발생하면 적절한 에러 메세지를 사용자에게 알려줘야합니다.

# 상세 기술

- 파이어베이스 SDK에서도 최소한의 유효성검사와 인증을 해주지만 그 전에 애플리케이션에서 정해둔 규칙에 맞게 추가로 검사를 한 뒤 파이어베이스 SDK쪽으로 정보를 제출하도록 로직을 구성하였습니다.

# 참고사항

- 라우터에 변경이 있으니 참고해주시기 바랍니다.
- 기존: 
  - `auth/refresh/kakao`(카카오 토큰을 리프레시)
- 변경: 
  - `auth/token/refresh`(앱 자체토큰을 리프레시)
  - `auth/token/validate`(앱 실행시 로컬스토리지에 앱 자체토큰이 있다면 앱 자체토큰이 유효한지 검사하는곳)

# PR 체크 사항

## 주의 사항

- [x]  PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x]  conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x]  가장 최신 브랜치를 pull 하였습니다.
- [x]  base 브랜치명을 확인하였습니다.
- [x]  코드 컨벤션을 모두 확인하였습니다.
- [x]  브랜치명을 확인하였습니다.
- [x]  작업 중 dependency 변경사항이 있는 경우 안내해주세요!


## 리뷰 반영사항

-
